### PR TITLE
Standardize course keys

### DIFF
--- a/content-manager-course-setup.ps1
+++ b/content-manager-course-setup.ps1
@@ -16,7 +16,7 @@ function install-course {
         "--pages-navigation" {
             $RepoUrl = "https://github.com/liferay/liferay-course-pages-navigation/archive/refs/heads/main.zip"
         }
-        "--seo" {
+        "--search-engine-optimization" {
             $RepoUrl = "https://github.com/liferay/liferay-course-search-engine-optimization/archive/refs/heads/main.zip"
         }
         "--content-search" {
@@ -25,7 +25,7 @@ function install-course {
         "--personalized-experiences" {
             $RepoUrl = "https://github.com/liferay/liferay-course-personalized-experiences/archive/refs/heads/main.zip"
         }
-        "--assets-contents" {
+        "--assets-and-content" {
             $RepoUrl = "https://github.com/liferay/liferay-course-assets-and-content/archive/refs/heads/main.zip"
         }
         Default {

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -36,7 +36,7 @@ case "$COURSE_KEY" in
   --pages-navigation)
     REPO_URL="https://github.com/liferay/liferay-course-pages-navigation/archive/refs/heads/main.zip"
     ;;
-  --seo)
+  --search-engine-optimization)
     REPO_URL="https://github.com/liferay/liferay-course-search-engine-optimization/archive/refs/heads/main.zip"
     ;;
     --content-search)
@@ -45,8 +45,8 @@ case "$COURSE_KEY" in
     --personalized-experiences)
     REPO_URL="https://github.com/liferay/liferay-course-personalized-experiences/archive/refs/heads/main.zip"
     ;;
-    --assets-contents)
-    REPO_URL="https://github.com/liferay/liferay-course-personalized-experiences/archive/refs/heads/main.zip"
+    --assets-and-content)
+    REPO_URL="https://github.com/liferay/liferay-course-assets-and-content/archive/refs/heads/main.zip"
     ;;
   *)
     echo "❌ Invalid course option: $COURSE_KEY"


### PR DESCRIPTION
This pull request:
* Changes keys `seo` to `search-engine-optimization` and `assets-contents` to `assets-and-content` in both scripts.
* Fixes link to Assets and Content course in shell script.

cc: @smbmatheus-lr, @jhanda 