### PR TITLE
Point BEWL repo branch to main

### DIFF
--- a/content-manager-course-setup.ps1
+++ b/content-manager-course-setup.ps1
@@ -29,7 +29,7 @@ function install-course {
             $RepoUrl = "https://github.com/liferay/liferay-course-assets-and-content/archive/refs/heads/main.zip"
         }
         "--building-enterprise-websites" {
-            $RepoUrl = "https://github.com/liferay/liferay-course-building-enterprise-websites/archive/refs/heads/master.zip"
+            $RepoUrl = "https://github.com/liferay/liferay-course-building-enterprise-websites/archive/refs/heads/main.zip"
         }
         Default {
             Write-Host "❌ Invalid or missing argument. Use --course1 or --course2."

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -49,7 +49,7 @@ case "$COURSE_KEY" in
     REPO_URL="https://github.com/liferay/liferay-course-assets-and-content/archive/refs/heads/main.zip"
     ;;
     --building-enterprise-websites)
-    REPO_URL="https://github.com/liferay/liferay-course-building-enterprise-websites/archive/refs/heads/master.zip"
+    REPO_URL="https://github.com/liferay/liferay-course-building-enterprise-websites/archive/refs/heads/main.zip"
     ;;
   *)
     echo "❌ Invalid course option: $COURSE_KEY"


### PR DESCRIPTION
Created the `main` branch in the BEWL repo [here](https://github.com/liferay/liferay-course-building-enterprise-websites/tree/main) so the reference is valid