### PR TITLE
Phase 1 bug fixes: JAVA_HOME, CATALINA_HOME, and gradle initBundle retry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.lock
 *.zip
 .DS_Store
+/.idea/

--- a/content-manager-course-setup.ps1
+++ b/content-manager-course-setup.ps1
@@ -150,6 +150,25 @@ function Get-JavaMajorVersion {
         New-Item $JavaMarkerFile -ItemType File | Out-Null
         Write-Host "✅ Java installed at $ZuluPath"
         java -version
+
+        # Persist JAVA_HOME for future sessions (idempotent)
+        $existingJavaHome = [System.Environment]::GetEnvironmentVariable("JAVA_HOME", [System.EnvironmentVariableTarget]::User)
+        if (-not $existingJavaHome) {
+            [System.Environment]::SetEnvironmentVariable("JAVA_HOME", $ZuluPath, [System.EnvironmentVariableTarget]::User)
+            Write-Host "📝 JAVA_HOME persisted to user environment."
+        } else {
+            Write-Host "ℹ️  JAVA_HOME already set in user environment ($existingJavaHome), skipping persistence."
+        }
+        # Persist PATH update for future sessions (idempotent)
+        $userPath = [System.Environment]::GetEnvironmentVariable("PATH", [System.EnvironmentVariableTarget]::User)
+        $zuluBin = "$ZuluPath\bin"
+        if ($userPath -notlike "*$zuluBin*") {
+            [System.Environment]::SetEnvironmentVariable("PATH", "$zuluBin;$userPath", [System.EnvironmentVariableTarget]::User)
+            Write-Host "📝 $zuluBin added to user PATH."
+        } else {
+            Write-Host "ℹ️  $zuluBin already in user PATH, skipping."
+        }
+        Write-Host "ℹ️  Open a new terminal for the JAVA_HOME and PATH changes to take effect."
     }
 
     $javaMajor = Get-JavaMajorVersion

--- a/content-manager-course-setup.ps1
+++ b/content-manager-course-setup.ps1
@@ -176,6 +176,20 @@ function Get-JavaMajorVersion {
             Write-Host "❌ Gradle failed with exit code $($p.ExitCode)"
             exit $p.ExitCode
         }
+
+    # Dynamically locate the Tomcat directory inside bundles\
+    $TomcatDir = Get-ChildItem -Path (Join-Path $ExtractPath "bundles") -Directory -Filter "tomcat-*" -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($null -eq $TomcatDir) {
+        Write-Host "⚠️  Could not find a Tomcat directory under bundles\. CATALINA_HOME not set."
+    } else {
+        $env:CATALINA_HOME = $TomcatDir.FullName
+        Write-Host "✅ CATALINA_HOME set to $($env:CATALINA_HOME)"
+        # Persist for future sessions (user scope, survives reboots)
+        [System.Environment]::SetEnvironmentVariable("CATALINA_HOME", $TomcatDir.FullName, [System.EnvironmentVariableTarget]::User)
+        Write-Host "📝 CATALINA_HOME persisted to user environment."
+    }
+
     Write-Host "✅ Done. Liferay bundle initialized. You may proceed to start your Liferay application now."
 return
 }

--- a/content-manager-course-setup.ps1
+++ b/content-manager-course-setup.ps1
@@ -190,11 +190,38 @@ function Get-JavaMajorVersion {
     Set-Location $ExtractPath
     Write-Host "🛠 Running Gradle init..."
 
-    $p = Start-Process -FilePath ".\gradlew.bat" -ArgumentList "initBundle  --no-daemon --console=plain" -Wait -PassThru -NoNewWindow
-        if ($p.ExitCode -ne 0) {
-            Write-Host "❌ Gradle failed with exit code $($p.ExitCode)"
-            exit $p.ExitCode
+    $gradleMaxAttempts = 3
+    $gradleSuccess = $false
+
+    for ($attempt = 1; $attempt -le $gradleMaxAttempts; $attempt++) {
+        $gradleLines = @()
+        & .\gradlew.bat initBundle --no-daemon --console=plain 2>&1 |
+            ForEach-Object { "$_" } |
+            Tee-Object -Variable gradleLines
+        $gradleExit = $LASTEXITCODE
+        $gradleOutput = $gradleLines -join "`n"
+
+        if ($gradleExit -eq 0) {
+            $gradleSuccess = $true
+            break
         }
+
+        if ($attempt -lt $gradleMaxAttempts) {
+            if ($gradleOutput -match "verifyBundle|checksum") {
+                Write-Host "❌ Bundle download failed (checksum mismatch). This is usually caused by a slow or interrupted connection. Retrying... (attempt $attempt of $gradleMaxAttempts)"
+            } else {
+                Write-Host "❌ Gradle initBundle failed (exit code $gradleExit). Retrying... (attempt $attempt of $gradleMaxAttempts)"
+            }
+            Write-Host "🧹 Cleaning partial download artifacts..."
+            Remove-Item -Path (Join-Path $ExtractPath "bundles") -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-Item -Path (Join-Path $ExtractPath ".gradle") -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    if (-not $gradleSuccess) {
+        Write-Host "❌ Setup failed after $gradleMaxAttempts attempts. Please check your internet connection and try running the script again."
+        exit 1
+    }
 
     # Dynamically locate the Tomcat directory inside bundles\
     $TomcatDir = Get-ChildItem -Path (Join-Path $ExtractPath "bundles") -Directory -Filter "tomcat-*" -ErrorAction SilentlyContinue |

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -163,6 +163,15 @@ install_zulu_jre() {
   export PATH="$JAVA_HOME/bin:$PATH"
   echo "✅ Java installed at $JAVA_HOME"
   "$JAVA_HOME/bin/java" -version
+
+  # Persist JAVA_HOME and PATH update for future sessions
+  for RC in "${HOME}/.bashrc" "${HOME}/.zshrc" "${HOME}/.profile"; do
+    if [[ -f "$RC" ]] && ! grep -qF "JAVA_HOME" "$RC"; then
+      printf '\nexport JAVA_HOME="%s"\nexport PATH="$JAVA_HOME/bin:$PATH"\n' "$JAVA_HOME" >> "$RC"
+      echo "📝 Persisted JAVA_HOME to $RC"
+    fi
+  done
+  echo "ℹ️  Open a new terminal or run 'source ~/.bashrc' (or ~/.zshrc) for the PATH changes to take effect."
 }
 
 use_or_install_java() {

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -230,7 +230,39 @@ REPO_TOPDIR="$CLEAN_NAME"
 cd "$REPO_TOPDIR"
 echo "🛠 Setting up course environment..."
 chmod +x ./gradlew || true
-./gradlew initBundle
+# === INIT BUNDLE with retry (up to 3 attempts) ===
+GRADLE_MAX_ATTEMPTS=3
+GRADLE_SUCCESS=false
+GRADLE_TMP=$(mktemp)
+
+for attempt in $(seq 1 $GRADLE_MAX_ATTEMPTS); do
+  set +e
+  ./gradlew initBundle 2>&1 | tee "$GRADLE_TMP"
+  GRADLE_EXIT=${PIPESTATUS[0]}
+  set -e
+
+  if [[ $GRADLE_EXIT -eq 0 ]]; then
+    GRADLE_SUCCESS=true
+    break
+  fi
+
+  if [[ $attempt -lt $GRADLE_MAX_ATTEMPTS ]]; then
+    if grep -qiE "verifyBundle|checksum" "$GRADLE_TMP"; then
+      echo "❌ Bundle download failed (checksum mismatch). This is usually caused by a slow or interrupted connection. Retrying... (attempt $attempt of $GRADLE_MAX_ATTEMPTS)"
+    else
+      echo "❌ Gradle initBundle failed (exit code $GRADLE_EXIT). Retrying... (attempt $attempt of $GRADLE_MAX_ATTEMPTS)"
+    fi
+    echo "🧹 Cleaning partial download artifacts..."
+    rm -rf bundles .gradle
+  fi
+done
+
+rm -f "$GRADLE_TMP"
+
+if [[ "$GRADLE_SUCCESS" != "true" ]]; then
+  echo "❌ Setup failed after $GRADLE_MAX_ATTEMPTS attempts. Please check your internet connection and try running the script again."
+  exit 1
+fi
 
 # Dynamically locate the Tomcat directory inside bundles/
 TOMCAT_DIR=$(find bundles -maxdepth 1 -type d -name 'tomcat-*' | head -n1)

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -223,4 +223,20 @@ echo "🛠 Setting up course environment..."
 chmod +x ./gradlew || true
 ./gradlew initBundle
 
+# Dynamically locate the Tomcat directory inside bundles/
+TOMCAT_DIR=$(find bundles -maxdepth 1 -type d -name 'tomcat-*' | head -n1)
+if [[ -z "$TOMCAT_DIR" ]]; then
+  echo "⚠️  Could not find a Tomcat directory under bundles/. CATALINA_HOME not set."
+else
+  export CATALINA_HOME="$(pwd)/$TOMCAT_DIR"
+  echo "✅ CATALINA_HOME set to $CATALINA_HOME"
+  # Persist for future sessions
+  for RC in "${HOME}/.bashrc" "${HOME}/.zshrc" "${HOME}/.profile"; do
+    if [[ -f "$RC" ]] && ! grep -qF "CATALINA_HOME" "$RC"; then
+      printf '\nexport CATALINA_HOME="%s"\n' "$CATALINA_HOME" >> "$RC"
+      echo "📝 Persisted CATALINA_HOME to $RC"
+    fi
+  done
+fi
+
 echo "✅ Done. Liferay bundle initialized. You may proceed to start your Liferay application now."


### PR DESCRIPTION
## Summary
This PR resolves all three critical bug fixes from the 2026 maintenance window 
(Phase 1 of the Course Launcher Tool improvement plan).

## Changes

### [ENBT-4103](https://liferay.atlassian.net/browse/ENBT-4103) · Fix JAVA_HOME not persisting between terminal sessions
- `.sh`: appends `JAVA_HOME` and `PATH` update to `~/.bashrc`, `~/.zshrc`, and 
  `~/.profile` after Zulu JRE install — idempotent, only if not already present.
- `.ps1`: persists `JAVA_HOME` and appends `$ZuluPath\bin` to user-scope `PATH` 
  via `SetEnvironmentVariable` — idempotent check before writing.
- Both scripts print a hint to open a new terminal for changes to take effect.

### [ENBT-4104](https://liferay.atlassian.net/browse/ENBT-4104) · Fix missing CATALINA_HOME after gradle initBundle
- `.sh`: dynamically locates `bundles/tomcat-*` after `initBundle` and exports 
  `CATALINA_HOME` for the current session. Persists to `.bashrc`, `.zshrc`, 
  and `.profile` (idempotent).
- `.ps1`: same discovery via `Get-ChildItem -Filter tomcat-*`. Sets 
  `$env:CATALINA_HOME` for the session and persists to user scope via 
  `SetEnvironmentVariable`.

### [ENBT-4105](https://liferay.atlassian.net/browse/ENBT-4105) · Fix invalid checksum on gradle initBundle (slow connections)
- Wraps `gradle initBundle` in a retry loop (up to 3 attempts) on both scripts.
- Cleans `bundles/` and `.gradle/` cache between retries.
- Detects `verifyBundle`/`checksum` keywords and shows a specific message; 
  falls back to a generic message for other errors.
- `.sh`: uses `set +e` / `tee` / `PIPESTATUS` for live streaming + exit code capture.
- `.ps1`: uses `& + Tee-Object -Variable` for zero-buffering live output and 
  `$LASTEXITCODE` for exit code detection.

## Testing
- [ ] ENBT-4103: Tested on clean machine (no Java) — JAVA_HOME persists after 
      reopening terminal on Linux, Mac, and Windows.
- [ ] ENBT-4104: Server starts without "CATALINA_HOME not defined" error after 
      running the script.
- [ ] CENBT-4105: Simulated slow/interrupted connection — script retries and 
      displays correct messages.