### PR TITLE
Phase 2: dynamic course key listing in error and usage messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.lock
 *.zip
 .DS_Store
+/.idea/

--- a/content-manager-course-setup.ps1
+++ b/content-manager-course-setup.ps1
@@ -1,5 +1,36 @@
 $ErrorActionPreference = "Stop"
 
+# === COURSES (grouped by learning path) ===
+$CoursesContentManager = @(
+    "--publishing-tool-and-content-lifecycle"
+    "--pages-navigation"
+    "--search-engine-optimization"
+    "--content-search"
+    "--personalized-experiences"
+    "--classic-cms"
+    "--content-management-system"
+)
+
+$CoursesSiteBuilding = @(
+    "--building-enterprise-websites"
+)
+
+$CoursesCommerce = @(
+    "--foundations-of-commerce"
+    "--users-and-accounts"
+    "--product-management"
+    "--inventory-management"
+    "--pricing"
+    "--order-management"
+    "--storefronts"
+)
+
+function Get-CourseKeys {
+    Write-Host "  Content Manager: $($script:CoursesContentManager -join ' | ')"
+    Write-Host "  Site Building:   $($script:CoursesSiteBuilding -join ' | ')"
+    Write-Host "  Commerce:        $($script:CoursesCommerce -join ' | ')"
+}
+
 function install-course {
     param(
         [string]$CourseKey
@@ -56,7 +87,9 @@ function install-course {
             $RepoUrl = "https://github.com/liferay/liferay-course-content-management-system/archive/refs/heads/main.zip"
         }
         Default {
-            Write-Host "❌ Invalid or missing argument. Use --course1 or --course2."
+            Write-Host "❌ Invalid or missing course key: $CourseKey"
+            Write-Host "Available courses:"
+            Get-CourseKeys
             return
         }
     }
@@ -245,6 +278,8 @@ if ($MyInvocation.InvocationName -eq '.\content-manager-course-setup.ps1' -or $M
     if ($args.Count -ge 1) {
         install-course $args[0]
     } else {
-        Write-Host "ℹ️ Usage: install-course --course1 | --course2"
+        Write-Host "ℹ️ Usage: .\content-manager-course-setup.ps1 <course-key>"
+        Write-Host "Available courses:"
+        Get-CourseKeys
     }
 }

--- a/content-manager-course-setup.ps1
+++ b/content-manager-course-setup.ps1
@@ -150,6 +150,25 @@ function Get-JavaMajorVersion {
         New-Item $JavaMarkerFile -ItemType File | Out-Null
         Write-Host "✅ Java installed at $ZuluPath"
         java -version
+
+        # Persist JAVA_HOME for future sessions (idempotent)
+        $existingJavaHome = [System.Environment]::GetEnvironmentVariable("JAVA_HOME", [System.EnvironmentVariableTarget]::User)
+        if (-not $existingJavaHome) {
+            [System.Environment]::SetEnvironmentVariable("JAVA_HOME", $ZuluPath, [System.EnvironmentVariableTarget]::User)
+            Write-Host "📝 JAVA_HOME persisted to user environment."
+        } else {
+            Write-Host "ℹ️  JAVA_HOME already set in user environment ($existingJavaHome), skipping persistence."
+        }
+        # Persist PATH update for future sessions (idempotent)
+        $userPath = [System.Environment]::GetEnvironmentVariable("PATH", [System.EnvironmentVariableTarget]::User)
+        $zuluBin = "$ZuluPath\bin"
+        if ($userPath -notlike "*$zuluBin*") {
+            [System.Environment]::SetEnvironmentVariable("PATH", "$zuluBin;$userPath", [System.EnvironmentVariableTarget]::User)
+            Write-Host "📝 $zuluBin added to user PATH."
+        } else {
+            Write-Host "ℹ️  $zuluBin already in user PATH, skipping."
+        }
+        Write-Host "ℹ️  Open a new terminal for the JAVA_HOME and PATH changes to take effect."
     }
 
     $javaMajor = Get-JavaMajorVersion

--- a/content-manager-course-setup.ps1
+++ b/content-manager-course-setup.ps1
@@ -176,6 +176,20 @@ function Get-JavaMajorVersion {
             Write-Host "❌ Gradle failed with exit code $($p.ExitCode)"
             exit $p.ExitCode
         }
+
+    # Dynamically locate the Tomcat directory inside bundles\
+    $TomcatDir = Get-ChildItem -Path (Join-Path $ExtractPath "bundles") -Directory -Filter "tomcat-*" -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($null -eq $TomcatDir) {
+        Write-Host "⚠️  Could not find a Tomcat directory under bundles\. CATALINA_HOME not set."
+    } else {
+        $env:CATALINA_HOME = $TomcatDir.FullName
+        Write-Host "✅ CATALINA_HOME set to $($env:CATALINA_HOME)"
+        # Persist for future sessions (user scope, survives reboots)
+        [System.Environment]::SetEnvironmentVariable("CATALINA_HOME", $TomcatDir.FullName, [System.EnvironmentVariableTarget]::User)
+        Write-Host "📝 CATALINA_HOME persisted to user environment."
+    }
+
     Write-Host "✅ Done. Liferay bundle initialized. You may proceed to start your Liferay application now."
 return
 }

--- a/content-manager-course-setup.ps1
+++ b/content-manager-course-setup.ps1
@@ -190,11 +190,38 @@ function Get-JavaMajorVersion {
     Set-Location $ExtractPath
     Write-Host "🛠 Running Gradle init..."
 
-    $p = Start-Process -FilePath ".\gradlew.bat" -ArgumentList "initBundle  --no-daemon --console=plain" -Wait -PassThru -NoNewWindow
-        if ($p.ExitCode -ne 0) {
-            Write-Host "❌ Gradle failed with exit code $($p.ExitCode)"
-            exit $p.ExitCode
+    $gradleMaxAttempts = 3
+    $gradleSuccess = $false
+
+    for ($attempt = 1; $attempt -le $gradleMaxAttempts; $attempt++) {
+        $gradleLines = @()
+        & .\gradlew.bat initBundle --no-daemon --console=plain 2>&1 |
+            ForEach-Object { "$_" } |
+            Tee-Object -Variable gradleLines
+        $gradleExit = $LASTEXITCODE
+        $gradleOutput = $gradleLines -join "`n"
+
+        if ($gradleExit -eq 0) {
+            $gradleSuccess = $true
+            break
         }
+
+        if ($attempt -lt $gradleMaxAttempts) {
+            if ($gradleOutput -match "verifyBundle|checksum") {
+                Write-Host "❌ Bundle download failed (checksum mismatch). This is usually caused by a slow or interrupted connection. Retrying... (attempt $attempt of $gradleMaxAttempts)"
+            } else {
+                Write-Host "❌ Gradle initBundle failed (exit code $gradleExit). Retrying... (attempt $attempt of $gradleMaxAttempts)"
+            }
+            Write-Host "🧹 Cleaning partial download artifacts..."
+            Remove-Item -Path (Join-Path $ExtractPath "bundles") -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-Item -Path (Join-Path $ExtractPath ".gradle") -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    if (-not $gradleSuccess) {
+        Write-Host "❌ Setup failed after $gradleMaxAttempts attempts. Please check your internet connection and try running the script again."
+        exit 1
+    }
 
     # Dynamically locate the Tomcat directory inside bundles\
     $TomcatDir = Get-ChildItem -Path (Join-Path $ExtractPath "bundles") -Directory -Filter "tomcat-*" -ErrorAction SilentlyContinue |

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -163,6 +163,15 @@ install_zulu_jre() {
   export PATH="$JAVA_HOME/bin:$PATH"
   echo "✅ Java installed at $JAVA_HOME"
   "$JAVA_HOME/bin/java" -version
+
+  # Persist JAVA_HOME and PATH update for future sessions
+  for RC in "${HOME}/.bashrc" "${HOME}/.zshrc" "${HOME}/.profile"; do
+    if [[ -f "$RC" ]] && ! grep -qF "JAVA_HOME" "$RC"; then
+      printf '\nexport JAVA_HOME="%s"\nexport PATH="$JAVA_HOME/bin:$PATH"\n' "$JAVA_HOME" >> "$RC"
+      echo "📝 Persisted JAVA_HOME to $RC"
+    fi
+  done
+  echo "ℹ️  Open a new terminal or run 'source ~/.bashrc' (or ~/.zshrc) for the PATH changes to take effect."
 }
 
 use_or_install_java() {

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -230,7 +230,39 @@ REPO_TOPDIR="$CLEAN_NAME"
 cd "$REPO_TOPDIR"
 echo "🛠 Setting up course environment..."
 chmod +x ./gradlew || true
-./gradlew initBundle
+# === INIT BUNDLE with retry (up to 3 attempts) ===
+GRADLE_MAX_ATTEMPTS=3
+GRADLE_SUCCESS=false
+GRADLE_TMP=$(mktemp)
+
+for attempt in $(seq 1 $GRADLE_MAX_ATTEMPTS); do
+  set +e
+  ./gradlew initBundle 2>&1 | tee "$GRADLE_TMP"
+  GRADLE_EXIT=${PIPESTATUS[0]}
+  set -e
+
+  if [[ $GRADLE_EXIT -eq 0 ]]; then
+    GRADLE_SUCCESS=true
+    break
+  fi
+
+  if [[ $attempt -lt $GRADLE_MAX_ATTEMPTS ]]; then
+    if grep -qiE "verifyBundle|checksum" "$GRADLE_TMP"; then
+      echo "❌ Bundle download failed (checksum mismatch). This is usually caused by a slow or interrupted connection. Retrying... (attempt $attempt of $GRADLE_MAX_ATTEMPTS)"
+    else
+      echo "❌ Gradle initBundle failed (exit code $GRADLE_EXIT). Retrying... (attempt $attempt of $GRADLE_MAX_ATTEMPTS)"
+    fi
+    echo "🧹 Cleaning partial download artifacts..."
+    rm -rf bundles .gradle
+  fi
+done
+
+rm -f "$GRADLE_TMP"
+
+if [[ "$GRADLE_SUCCESS" != "true" ]]; then
+  echo "❌ Setup failed after $GRADLE_MAX_ATTEMPTS attempts. Please check your internet connection and try running the script again."
+  exit 1
+fi
 
 # Dynamically locate the Tomcat directory inside bundles/
 TOMCAT_DIR=$(find bundles -maxdepth 1 -type d -name 'tomcat-*' | head -n1)

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -223,4 +223,20 @@ echo "🛠 Setting up course environment..."
 chmod +x ./gradlew || true
 ./gradlew initBundle
 
+# Dynamically locate the Tomcat directory inside bundles/
+TOMCAT_DIR=$(find bundles -maxdepth 1 -type d -name 'tomcat-*' | head -n1)
+if [[ -z "$TOMCAT_DIR" ]]; then
+  echo "⚠️  Could not find a Tomcat directory under bundles/. CATALINA_HOME not set."
+else
+  export CATALINA_HOME="$(pwd)/$TOMCAT_DIR"
+  echo "✅ CATALINA_HOME set to $CATALINA_HOME"
+  # Persist for future sessions
+  for RC in "${HOME}/.bashrc" "${HOME}/.zshrc" "${HOME}/.profile"; do
+    if [[ -f "$RC" ]] && ! grep -qF "CATALINA_HOME" "$RC"; then
+      printf '\nexport CATALINA_HOME="%s"\n' "$CATALINA_HOME" >> "$RC"
+      echo "📝 Persisted CATALINA_HOME to $RC"
+    fi
+  done
+fi
+
 echo "✅ Done. Liferay bundle initialized. You may proceed to start your Liferay application now."

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -6,12 +6,48 @@ JAVA_REQUIRED_VERSION="21.0.1"
 RUNTIME_DIR="${HOME}/.liferay-course-runtime"
 JAVA_DIR="${RUNTIME_DIR}/zulu-java-21"
 
+# === COURSES (grouped by learning path) ===
+COURSES_CONTENT_MANAGER=(
+  --publishing-tool-and-content-lifecycle
+  --pages-navigation
+  --search-engine-optimization
+  --content-search
+  --personalized-experiences
+  --classic-cms
+  --content-management-system
+)
+
+COURSES_SITE_BUILDING=(
+  --building-enterprise-websites
+)
+
+COURSES_COMMERCE=(
+  --foundations-of-commerce
+  --users-and-accounts
+  --product-management
+  --inventory-management
+  --pricing
+  --order-management
+  --storefronts
+)
+
+list_course_keys() {
+  local joined
+  printf -v joined '%s | ' "${COURSES_CONTENT_MANAGER[@]}"
+  echo "  Content Manager: ${joined% | }"
+  printf -v joined '%s | ' "${COURSES_SITE_BUILDING[@]}"
+  echo "  Site Building:   ${joined% | }"
+  printf -v joined '%s | ' "${COURSES_COMMERCE[@]}"
+  echo "  Commerce:        ${joined% | }"
+}
+
 # === ARGUMENTS ===
 if [[ $# -ne 2 ]]; then
   echo "❌ Wrong usage."
   echo "Usage:"
-  echo "  bash -c \"\$(curl -fsSL <url>)\" -- --course1 mac"
-  echo "  bash -c \"\$(curl -fsSL <url>)\" -- --course2 linux"
+  echo "  bash -c \"\$(curl -fsSL <url>)\" -- <course-key> mac|linux"
+  echo "Available courses:"
+  list_course_keys
   exit 1
 fi
 
@@ -19,13 +55,13 @@ COURSE_KEY="$1"
 OS_INPUT="$2"
 
 if [[ "$COURSE_KEY" == "--help" ]]; then
-  echo "📚 Available options:"
-  echo "  --course1     Install Backend Client Extensions course"
-  echo "  --course2     Install Frontend Client Extensions course"
+  echo "📚 Available courses:"
+  list_course_keys
+  echo
   echo "  --help        Show this help message"
   echo
   echo "📦 Example usage:"
-  echo "  bash -c \"\$(curl -fsSL <url>)\" -- --course1 mac"
+  echo "  bash -c \"\$(curl -fsSL <url>)\" -- --pages-navigation mac"
   exit 0
 fi
 
@@ -77,7 +113,8 @@ case "$COURSE_KEY" in
     ;;
   *)
     echo "❌ Invalid course option: $COURSE_KEY"
-    echo "Use: --course1 | --course2"
+    echo "Available courses:"
+    list_course_keys
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary
This PR resolves the Phase 2 improvement from the 2026 maintenance window —
replacing all hardcoded course names and generic placeholders in error/usage
messages with dynamically generated output grouped by learning path.

> ⚠️ This branch is based on `ENBT-4105` (Phase 1). Please merge Phase 1 first.

## Changes

### ENBT-2686 · Dynamic course key listing in error and usage messages

**Both scripts:**
- Introduced three course arrays grouped by learning path:
  `COURSES_CONTENT_MANAGER`, `COURSES_SITE_BUILDING`, `COURSES_COMMERCE`
- Added a reusable helper (`list_course_keys` in `.sh` / `Get-CourseKeys` 
  in `.ps1`) that formats and prints all available keys grouped by learning path

**.sh — 3 locations updated:**
- Wrong usage message (lines 13–14): now shows `<course-key> mac|linux` 
  + dynamic key list
- `--help` output (lines 23–24): now calls `list_course_keys` + updated 
  example to use a real key (`--pages-navigation`)
- Invalid course error (line 59): replaced `Use: --course1 | --course2` 
  with dynamic key list

**.ps1 — 2 locations updated:**
- `Default` branch: replaced generic placeholder with `Get-CourseKeys`
- Direct execution block: replaced hardcoded usage line with `Get-CourseKeys`

## Testing
- [ ] Running the script with an invalid course key shows the correct 
      dynamic list grouped by learning path — Linux/Mac
- [ ] Running the script with an invalid course key shows the correct 
      dynamic list grouped by learning path — Windows
- [ ] `--help` flag displays all course keys correctly grouped

## Related tickets
Resolves ENBT-2686

## PR chain
- Phase 1: #11 (ENBT-4105) — pending merge
- Phase 2: this PR — pending Phase 1 merge