### PR TITLE
Phase 4: README contributor guide and course setup commands reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.lock
 *.zip
 .DS_Store
+/.idea/

--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@ This tool:
 * Downloads and configures the course workspace.
 * Initializes the local Liferay DXP bundle.
 
+## Repository Structure
+
+```
+course-launcher/
+├── course-setup.sh          # Linux/Mac launcher
+├── course-setup.ps1         # Windows launcher
+└── courses/
+    ├── commerce.conf
+    ├── content-manager.conf
+    └── site-building.conf
+```
+
 ## Table of Contents
 
 * [Setting Up the Clarity Workspace](#setting-up-the-clarity-workspace)
@@ -24,17 +36,17 @@ Here, you'll execute the course launcher tool to prepare your system and set up 
    **Linux/Unix**:
 
    ```bash
-   /bin/bash -c "$(curl -fsSL https://raw.github.com/liferay/liferay-enablement-script-library/main/content-manager-course-setup.sh)" -- --[COURSE-NAME] linux
+   /bin/bash -c "$(curl -fsSL https://raw.github.com/liferay/liferay-enablement-script-library/main/course-launcher/course-setup.sh)" -- --[COURSE-NAME] linux
    ```
 
    **Mac**:
    ```bash
-   /bin/bash -c "$(curl -fsSL https://raw.github.com/liferay/liferay-enablement-script-library/main/content-manager-course-setup.sh)" -- --[COURSE-NAME] mac
+   /bin/bash -c "$(curl -fsSL https://raw.github.com/liferay/liferay-enablement-script-library/main/course-launcher/course-setup.sh)" -- --[COURSE-NAME] mac
    ```
 
    **Windows**:
    ```bash
-   powershell Set-ExecutionPolicy Bypass -Scope Process -Force; iex "& { $(irm https://raw.githubusercontent.com/liferay/liferay-enablement-script-library/refs/heads/main/content-manager-course-setup.ps1); install-course --[COURSE-NAME] }"
+   powershell Set-ExecutionPolicy Bypass -Scope Process -Force; iex "& { $(irm https://raw.githubusercontent.com/liferay/liferay-enablement-script-library/refs/heads/main/course-launcher/course-setup.ps1); install-course --[COURSE-NAME] }"
    ```
 
    This executes the course launcher tool, which automatically checks for and installs Java JDK 21, downloads the course's files, and prepares the Liferay DXP bundle.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,126 @@ course-launcher/
     └── site-building.conf
 ```
 
+## Course Key Convention
+
+All course keys follow this naming convention:
+
+```
+key = repository name minus the "liferay-course-" prefix
+```
+
+Examples:
+
+| Repository | Key |
+|---|---|
+| `liferay-course-pages-navigation` | `--pages-navigation` |
+| `liferay-course-commerce-pricing` | `--commerce-pricing` |
+| `liferay-course-building-enterprise-websites` | `--building-enterprise-websites` |
+
+This convention applies to all learning paths. When in doubt, check the corresponding GitHub repository name under https://github.com/liferay.
+
+## Adding a New Course
+
+### To an existing learning path
+
+1. Open the corresponding `.conf` file under `course-launcher/courses/`.
+
+   Example: to add a new course to the Content Manager learning path, open `course-launcher/courses/content-manager.conf`:
+
+   ```
+   LEARNING_PATH="Content Manager"
+   COURSES=(
+     --publishing-tool-and-content-lifecycle
+     --pages-navigation
+     --search-engine-optimization
+     --content-search
+     --personalized-experiences
+     --classic-cms
+     --content-management-system
+     --your-new-course-key   ← add the new key here
+   )
+   ```
+
+2. Add the new course key following the naming convention: `key = repository name minus the "liferay-course-" prefix`.
+
+   Example: for a repo named `liferay-course-content-staging`, add:
+
+   ```
+   --content-staging
+   ```
+
+3. Update the one-line fallback entry for that learning path in both `course-launcher/course-setup.sh` and `course-launcher/course-setup.ps1`. Search for the `# Keep in sync` comment to find the right place.
+
+   Example in `course-setup.sh`:
+
+   ```bash
+   # Keep in sync with course-launcher/courses/content-manager.conf
+   "--publishing-tool-and-content-lifecycle --pages-navigation --search-engine-optimization --content-search --personalized-experiences --classic-cms --content-management-system --content-staging"
+   ```
+
+   Example in `course-setup.ps1`:
+
+   ```powershell
+   # Keep in sync with course-launcher/courses/content-manager.conf
+   [PSCustomObject]@{ LearningPath = "Content Manager"; Courses = @("--publishing-tool-and-content-lifecycle", "--pages-navigation", "--search-engine-optimization", "--content-search", "--personalized-experiences", "--classic-cms", "--content-management-system", "--content-staging") }
+   ```
+
+4. No other changes to the main scripts are needed.
+
+### To a new learning path
+
+1. Create a new `.conf` file under `course-launcher/courses/` following the format of the existing files.
+
+   Example: to add a "Developer" learning path, create `course-launcher/courses/developer.conf`:
+
+   ```
+   LEARNING_PATH="Developer"
+   COURSES=(
+     --your-first-course-key
+     --your-second-course-key
+   )
+   ```
+
+2. Add a one-line fallback entry in both scripts. Search for the `# Keep in sync` comment and add a new line following the same pattern as the existing entries.
+
+   Example in `course-setup.sh`:
+
+   ```bash
+   # Keep in sync with course-launcher/courses/developer.conf
+   "--your-first-course-key --your-second-course-key"
+   ```
+
+   Example in `course-setup.ps1`:
+
+   ```powershell
+   # Keep in sync with course-launcher/courses/developer.conf
+   [PSCustomObject]@{ LearningPath = "Developer"; Courses = @("--your-first-course-key", "--your-second-course-key") }
+   ```
+
+3. No other changes to the main scripts are needed.
+
+## Troubleshooting
+
+### JAVA_HOME not found after reopening the terminal
+
+This was a known issue fixed in the 2026 maintenance window. If you installed Java via the course launcher and JAVA_HOME is missing in a new terminal:
+
+- **Linux/Mac**: run `source ~/.bashrc` or `source ~/.zshrc`, then try again.
+- **Windows**: open a new terminal window — the variable was persisted to your user environment and will be available in any new session.
+
+If the issue persists, re-run the setup script — it will detect the existing Java installation and skip the download.
+
+### Server fails to start with "CATALINA_HOME not defined"
+
+This was a known issue fixed in the 2026 maintenance window. Re-run the setup script to set CATALINA_HOME correctly for your session.
+
+### gradle initBundle fails with a checksum error
+
+This is usually caused by a slow or interrupted internet connection. The setup script automatically retries up to 3 times and cleans any partial downloads between attempts. If all 3 attempts fail:
+
+1. Check your internet connection.
+2. Re-run the setup script — it will retry the download from scratch.
+
 ## Table of Contents
 
 * [Setting Up the Clarity Workspace](#setting-up-the-clarity-workspace)

--- a/content-manager-course-setup.ps1
+++ b/content-manager-course-setup.ps1
@@ -1,5 +1,36 @@
 $ErrorActionPreference = "Stop"
 
+# === COURSES (grouped by learning path) ===
+$CoursesContentManager = @(
+    "--publishing-tool-and-content-lifecycle"
+    "--pages-navigation"
+    "--search-engine-optimization"
+    "--content-search"
+    "--personalized-experiences"
+    "--classic-cms"
+    "--content-management-system"
+)
+
+$CoursesSiteBuilding = @(
+    "--building-enterprise-websites"
+)
+
+$CoursesCommerce = @(
+    "--foundations-of-commerce"
+    "--users-and-accounts"
+    "--product-management"
+    "--inventory-management"
+    "--pricing"
+    "--order-management"
+    "--storefronts"
+)
+
+function Get-CourseKeys {
+    Write-Host "  Content Manager: $($script:CoursesContentManager -join ' | ')"
+    Write-Host "  Site Building:   $($script:CoursesSiteBuilding -join ' | ')"
+    Write-Host "  Commerce:        $($script:CoursesCommerce -join ' | ')"
+}
+
 function install-course {
     param(
         [string]$CourseKey
@@ -56,7 +87,9 @@ function install-course {
             $RepoUrl = "https://github.com/liferay/liferay-course-content-management-system/archive/refs/heads/main.zip"
         }
         Default {
-            Write-Host "❌ Invalid or missing argument. Use --course1 or --course2."
+            Write-Host "❌ Invalid or missing course key: $CourseKey"
+            Write-Host "Available courses:"
+            Get-CourseKeys
             return
         }
     }
@@ -245,6 +278,8 @@ if ($MyInvocation.InvocationName -eq '.\content-manager-course-setup.ps1' -or $M
     if ($args.Count -ge 1) {
         install-course $args[0]
     } else {
-        Write-Host "ℹ️ Usage: install-course --course1 | --course2"
+        Write-Host "ℹ️ Usage: .\content-manager-course-setup.ps1 <course-key>"
+        Write-Host "Available courses:"
+        Get-CourseKeys
     }
 }

--- a/content-manager-course-setup.ps1
+++ b/content-manager-course-setup.ps1
@@ -1,34 +1,79 @@
 $ErrorActionPreference = "Stop"
 
-# === COURSES (grouped by learning path) ===
-$CoursesContentManager = @(
-    "--publishing-tool-and-content-lifecycle"
-    "--pages-navigation"
-    "--search-engine-optimization"
-    "--content-search"
-    "--personalized-experiences"
-    "--classic-cms"
-    "--content-management-system"
+# === COURSES (loaded dynamically from course-launcher/courses/*.conf) ===
+function Import-CourseConfigs {
+    param([string]$ConfDir)
+    $configs = [System.Collections.Generic.List[PSCustomObject]]::new()
+    foreach ($file in Get-ChildItem -Path $ConfDir -Filter "*.conf" | Sort-Object Name) {
+        $learningPath = $null
+        $courses = [System.Collections.Generic.List[string]]::new()
+        $inCourses = $false
+        foreach ($line in Get-Content $file.FullName) {
+            $trimmed = $line.Trim()
+            if ($trimmed -match '^LEARNING_PATH="(.+)"$') {
+                $learningPath = $Matches[1]
+            } elseif ($trimmed -eq 'COURSES=(') {
+                $inCourses = $true
+            } elseif ($trimmed -eq ')' -and $inCourses) {
+                $inCourses = $false
+            } elseif ($inCourses -and $trimmed -ne '') {
+                $courses.Add($trimmed)
+            }
+        }
+        if ($learningPath -and $courses.Count -gt 0) {
+            $configs.Add([PSCustomObject]@{ LearningPath = $learningPath; Courses = $courses.ToArray() })
+        }
+    }
+    return ,$configs
+}
+
+# Fallback used when .conf files are unreachable (e.g. iex/irm invocation).
+# Keep in sync with course-launcher/courses/*.conf.
+$_LearningPaths = @(
+    [PSCustomObject]@{
+        LearningPath = "Content Manager"
+        Courses = @(
+            "--publishing-tool-and-content-lifecycle"
+            "--pages-navigation"
+            "--search-engine-optimization"
+            "--content-search"
+            "--personalized-experiences"
+            "--classic-cms"
+            "--content-management-system"
+        )
+    }
+    [PSCustomObject]@{
+        LearningPath = "Site Building"
+        Courses = @("--building-enterprise-websites")
+    }
+    [PSCustomObject]@{
+        LearningPath = "Commerce"
+        Courses = @(
+            "--foundations-of-commerce"
+            "--users-and-accounts"
+            "--product-management"
+            "--inventory-management"
+            "--pricing"
+            "--order-management"
+            "--storefronts"
+        )
+    }
 )
 
-$CoursesSiteBuilding = @(
-    "--building-enterprise-websites"
-)
-
-$CoursesCommerce = @(
-    "--foundations-of-commerce"
-    "--users-and-accounts"
-    "--product-management"
-    "--inventory-management"
-    "--pricing"
-    "--order-management"
-    "--storefronts"
-)
+# Override fallback with .conf files when running from a local checkout
+$_ScriptPath = $MyInvocation.MyCommand.Path
+if ($_ScriptPath) {
+    $_ConfDir = Join-Path (Split-Path -Parent $_ScriptPath) "course-launcher\courses"
+    if (Test-Path $_ConfDir) {
+        $_loaded = Import-CourseConfigs -ConfDir $_ConfDir
+        if ($_loaded.Count -gt 0) { $_LearningPaths = $_loaded }
+    }
+}
 
 function Get-CourseKeys {
-    Write-Host "  Content Manager: $($script:CoursesContentManager -join ' | ')"
-    Write-Host "  Site Building:   $($script:CoursesSiteBuilding -join ' | ')"
-    Write-Host "  Commerce:        $($script:CoursesCommerce -join ' | ')"
+    foreach ($lp in $script:_LearningPaths) {
+        Write-Host "  $($lp.LearningPath): $($lp.Courses -join ' | ')"
+    }
 }
 
 function install-course {

--- a/content-manager-course-setup.ps1
+++ b/content-manager-course-setup.ps1
@@ -150,6 +150,25 @@ function Get-JavaMajorVersion {
         New-Item $JavaMarkerFile -ItemType File | Out-Null
         Write-Host "✅ Java installed at $ZuluPath"
         java -version
+
+        # Persist JAVA_HOME for future sessions (idempotent)
+        $existingJavaHome = [System.Environment]::GetEnvironmentVariable("JAVA_HOME", [System.EnvironmentVariableTarget]::User)
+        if (-not $existingJavaHome) {
+            [System.Environment]::SetEnvironmentVariable("JAVA_HOME", $ZuluPath, [System.EnvironmentVariableTarget]::User)
+            Write-Host "📝 JAVA_HOME persisted to user environment."
+        } else {
+            Write-Host "ℹ️  JAVA_HOME already set in user environment ($existingJavaHome), skipping persistence."
+        }
+        # Persist PATH update for future sessions (idempotent)
+        $userPath = [System.Environment]::GetEnvironmentVariable("PATH", [System.EnvironmentVariableTarget]::User)
+        $zuluBin = "$ZuluPath\bin"
+        if ($userPath -notlike "*$zuluBin*") {
+            [System.Environment]::SetEnvironmentVariable("PATH", "$zuluBin;$userPath", [System.EnvironmentVariableTarget]::User)
+            Write-Host "📝 $zuluBin added to user PATH."
+        } else {
+            Write-Host "ℹ️  $zuluBin already in user PATH, skipping."
+        }
+        Write-Host "ℹ️  Open a new terminal for the JAVA_HOME and PATH changes to take effect."
     }
 
     $javaMajor = Get-JavaMajorVersion

--- a/content-manager-course-setup.ps1
+++ b/content-manager-course-setup.ps1
@@ -176,6 +176,20 @@ function Get-JavaMajorVersion {
             Write-Host "❌ Gradle failed with exit code $($p.ExitCode)"
             exit $p.ExitCode
         }
+
+    # Dynamically locate the Tomcat directory inside bundles\
+    $TomcatDir = Get-ChildItem -Path (Join-Path $ExtractPath "bundles") -Directory -Filter "tomcat-*" -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($null -eq $TomcatDir) {
+        Write-Host "⚠️  Could not find a Tomcat directory under bundles\. CATALINA_HOME not set."
+    } else {
+        $env:CATALINA_HOME = $TomcatDir.FullName
+        Write-Host "✅ CATALINA_HOME set to $($env:CATALINA_HOME)"
+        # Persist for future sessions (user scope, survives reboots)
+        [System.Environment]::SetEnvironmentVariable("CATALINA_HOME", $TomcatDir.FullName, [System.EnvironmentVariableTarget]::User)
+        Write-Host "📝 CATALINA_HOME persisted to user environment."
+    }
+
     Write-Host "✅ Done. Liferay bundle initialized. You may proceed to start your Liferay application now."
 return
 }

--- a/content-manager-course-setup.ps1
+++ b/content-manager-course-setup.ps1
@@ -190,11 +190,38 @@ function Get-JavaMajorVersion {
     Set-Location $ExtractPath
     Write-Host "🛠 Running Gradle init..."
 
-    $p = Start-Process -FilePath ".\gradlew.bat" -ArgumentList "initBundle  --no-daemon --console=plain" -Wait -PassThru -NoNewWindow
-        if ($p.ExitCode -ne 0) {
-            Write-Host "❌ Gradle failed with exit code $($p.ExitCode)"
-            exit $p.ExitCode
+    $gradleMaxAttempts = 3
+    $gradleSuccess = $false
+
+    for ($attempt = 1; $attempt -le $gradleMaxAttempts; $attempt++) {
+        $gradleLines = @()
+        & .\gradlew.bat initBundle --no-daemon --console=plain 2>&1 |
+            ForEach-Object { "$_" } |
+            Tee-Object -Variable gradleLines
+        $gradleExit = $LASTEXITCODE
+        $gradleOutput = $gradleLines -join "`n"
+
+        if ($gradleExit -eq 0) {
+            $gradleSuccess = $true
+            break
         }
+
+        if ($attempt -lt $gradleMaxAttempts) {
+            if ($gradleOutput -match "verifyBundle|checksum") {
+                Write-Host "❌ Bundle download failed (checksum mismatch). This is usually caused by a slow or interrupted connection. Retrying... (attempt $attempt of $gradleMaxAttempts)"
+            } else {
+                Write-Host "❌ Gradle initBundle failed (exit code $gradleExit). Retrying... (attempt $attempt of $gradleMaxAttempts)"
+            }
+            Write-Host "🧹 Cleaning partial download artifacts..."
+            Remove-Item -Path (Join-Path $ExtractPath "bundles") -Recurse -Force -ErrorAction SilentlyContinue
+            Remove-Item -Path (Join-Path $ExtractPath ".gradle") -Recurse -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    if (-not $gradleSuccess) {
+        Write-Host "❌ Setup failed after $gradleMaxAttempts attempts. Please check your internet connection and try running the script again."
+        exit 1
+    }
 
     # Dynamically locate the Tomcat directory inside bundles\
     $TomcatDir = Get-ChildItem -Path (Join-Path $ExtractPath "bundles") -Directory -Filter "tomcat-*" -ErrorAction SilentlyContinue |

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -163,6 +163,15 @@ install_zulu_jre() {
   export PATH="$JAVA_HOME/bin:$PATH"
   echo "✅ Java installed at $JAVA_HOME"
   "$JAVA_HOME/bin/java" -version
+
+  # Persist JAVA_HOME and PATH update for future sessions
+  for RC in "${HOME}/.bashrc" "${HOME}/.zshrc" "${HOME}/.profile"; do
+    if [[ -f "$RC" ]] && ! grep -qF "JAVA_HOME" "$RC"; then
+      printf '\nexport JAVA_HOME="%s"\nexport PATH="$JAVA_HOME/bin:$PATH"\n' "$JAVA_HOME" >> "$RC"
+      echo "📝 Persisted JAVA_HOME to $RC"
+    fi
+  done
+  echo "ℹ️  Open a new terminal or run 'source ~/.bashrc' (or ~/.zshrc) for the PATH changes to take effect."
 }
 
 use_or_install_java() {

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -6,39 +6,45 @@ JAVA_REQUIRED_VERSION="21.0.1"
 RUNTIME_DIR="${HOME}/.liferay-course-runtime"
 JAVA_DIR="${RUNTIME_DIR}/zulu-java-21"
 
-# === COURSES (grouped by learning path) ===
-COURSES_CONTENT_MANAGER=(
-  --publishing-tool-and-content-lifecycle
-  --pages-navigation
-  --search-engine-optimization
-  --content-search
-  --personalized-experiences
-  --classic-cms
-  --content-management-system
+# === COURSES (loaded dynamically from course-launcher/courses/*.conf) ===
+# Fallback used when .conf files are unreachable (e.g. curl invocation).
+# Keep in sync with course-launcher/courses/*.conf.
+declare -a _LP_NAMES=("Content Manager" "Site Building" "Commerce")
+declare -a _LP_COURSES=(
+  "--publishing-tool-and-content-lifecycle --pages-navigation --search-engine-optimization --content-search --personalized-experiences --classic-cms --content-management-system"
+  "--building-enterprise-websites"
+  "--foundations-of-commerce --users-and-accounts --product-management --inventory-management --pricing --order-management --storefronts"
 )
 
-COURSES_SITE_BUILDING=(
-  --building-enterprise-websites
-)
+_load_course_configs() {
+  local conf_dir
+  conf_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/course-launcher/courses"
+  [[ -d "$conf_dir" ]] || return
+  local _found=0
+  for conf_file in "${conf_dir}"/*.conf; do
+    [[ -f "$conf_file" ]] && { _found=1; break; }
+  done
+  [[ $_found -eq 0 ]] && return
+  # Conf files present — replace fallback entirely
+  _LP_NAMES=()
+  _LP_COURSES=()
+  for conf_file in "${conf_dir}"/*.conf; do
+    [[ -f "$conf_file" ]] || continue
+    unset LEARNING_PATH COURSES
+    # shellcheck source=/dev/null
+    source "$conf_file"
+    _LP_NAMES+=("$LEARNING_PATH")
+    _LP_COURSES+=("${COURSES[*]}")
+  done
+}
 
-COURSES_COMMERCE=(
-  --foundations-of-commerce
-  --users-and-accounts
-  --product-management
-  --inventory-management
-  --pricing
-  --order-management
-  --storefronts
-)
+_load_course_configs
 
 list_course_keys() {
-  local joined
-  printf -v joined '%s | ' "${COURSES_CONTENT_MANAGER[@]}"
-  echo "  Content Manager: ${joined% | }"
-  printf -v joined '%s | ' "${COURSES_SITE_BUILDING[@]}"
-  echo "  Site Building:   ${joined% | }"
-  printf -v joined '%s | ' "${COURSES_COMMERCE[@]}"
-  echo "  Commerce:        ${joined% | }"
+  for i in "${!_LP_NAMES[@]}"; do
+    local joined="${_LP_COURSES[$i]// / | }"
+    printf "  %s: %s\n" "${_LP_NAMES[$i]}" "$joined"
+  done
 }
 
 # === ARGUMENTS ===

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -230,7 +230,39 @@ REPO_TOPDIR="$CLEAN_NAME"
 cd "$REPO_TOPDIR"
 echo "🛠 Setting up course environment..."
 chmod +x ./gradlew || true
-./gradlew initBundle
+# === INIT BUNDLE with retry (up to 3 attempts) ===
+GRADLE_MAX_ATTEMPTS=3
+GRADLE_SUCCESS=false
+GRADLE_TMP=$(mktemp)
+
+for attempt in $(seq 1 $GRADLE_MAX_ATTEMPTS); do
+  set +e
+  ./gradlew initBundle 2>&1 | tee "$GRADLE_TMP"
+  GRADLE_EXIT=${PIPESTATUS[0]}
+  set -e
+
+  if [[ $GRADLE_EXIT -eq 0 ]]; then
+    GRADLE_SUCCESS=true
+    break
+  fi
+
+  if [[ $attempt -lt $GRADLE_MAX_ATTEMPTS ]]; then
+    if grep -qiE "verifyBundle|checksum" "$GRADLE_TMP"; then
+      echo "❌ Bundle download failed (checksum mismatch). This is usually caused by a slow or interrupted connection. Retrying... (attempt $attempt of $GRADLE_MAX_ATTEMPTS)"
+    else
+      echo "❌ Gradle initBundle failed (exit code $GRADLE_EXIT). Retrying... (attempt $attempt of $GRADLE_MAX_ATTEMPTS)"
+    fi
+    echo "🧹 Cleaning partial download artifacts..."
+    rm -rf bundles .gradle
+  fi
+done
+
+rm -f "$GRADLE_TMP"
+
+if [[ "$GRADLE_SUCCESS" != "true" ]]; then
+  echo "❌ Setup failed after $GRADLE_MAX_ATTEMPTS attempts. Please check your internet connection and try running the script again."
+  exit 1
+fi
 
 # Dynamically locate the Tomcat directory inside bundles/
 TOMCAT_DIR=$(find bundles -maxdepth 1 -type d -name 'tomcat-*' | head -n1)

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -223,4 +223,20 @@ echo "🛠 Setting up course environment..."
 chmod +x ./gradlew || true
 ./gradlew initBundle
 
+# Dynamically locate the Tomcat directory inside bundles/
+TOMCAT_DIR=$(find bundles -maxdepth 1 -type d -name 'tomcat-*' | head -n1)
+if [[ -z "$TOMCAT_DIR" ]]; then
+  echo "⚠️  Could not find a Tomcat directory under bundles/. CATALINA_HOME not set."
+else
+  export CATALINA_HOME="$(pwd)/$TOMCAT_DIR"
+  echo "✅ CATALINA_HOME set to $CATALINA_HOME"
+  # Persist for future sessions
+  for RC in "${HOME}/.bashrc" "${HOME}/.zshrc" "${HOME}/.profile"; do
+    if [[ -f "$RC" ]] && ! grep -qF "CATALINA_HOME" "$RC"; then
+      printf '\nexport CATALINA_HOME="%s"\n' "$CATALINA_HOME" >> "$RC"
+      echo "📝 Persisted CATALINA_HOME to $RC"
+    fi
+  done
+fi
+
 echo "✅ Done. Liferay bundle initialized. You may proceed to start your Liferay application now."

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -6,12 +6,48 @@ JAVA_REQUIRED_VERSION="21.0.1"
 RUNTIME_DIR="${HOME}/.liferay-course-runtime"
 JAVA_DIR="${RUNTIME_DIR}/zulu-java-21"
 
+# === COURSES (grouped by learning path) ===
+COURSES_CONTENT_MANAGER=(
+  --publishing-tool-and-content-lifecycle
+  --pages-navigation
+  --search-engine-optimization
+  --content-search
+  --personalized-experiences
+  --classic-cms
+  --content-management-system
+)
+
+COURSES_SITE_BUILDING=(
+  --building-enterprise-websites
+)
+
+COURSES_COMMERCE=(
+  --foundations-of-commerce
+  --users-and-accounts
+  --product-management
+  --inventory-management
+  --pricing
+  --order-management
+  --storefronts
+)
+
+list_course_keys() {
+  local joined
+  printf -v joined '%s | ' "${COURSES_CONTENT_MANAGER[@]}"
+  echo "  Content Manager: ${joined% | }"
+  printf -v joined '%s | ' "${COURSES_SITE_BUILDING[@]}"
+  echo "  Site Building:   ${joined% | }"
+  printf -v joined '%s | ' "${COURSES_COMMERCE[@]}"
+  echo "  Commerce:        ${joined% | }"
+}
+
 # === ARGUMENTS ===
 if [[ $# -ne 2 ]]; then
   echo "❌ Wrong usage."
   echo "Usage:"
-  echo "  bash -c \"\$(curl -fsSL <url>)\" -- --course1 mac"
-  echo "  bash -c \"\$(curl -fsSL <url>)\" -- --course2 linux"
+  echo "  bash -c \"\$(curl -fsSL <url>)\" -- <course-key> mac|linux"
+  echo "Available courses:"
+  list_course_keys
   exit 1
 fi
 
@@ -19,13 +55,13 @@ COURSE_KEY="$1"
 OS_INPUT="$2"
 
 if [[ "$COURSE_KEY" == "--help" ]]; then
-  echo "📚 Available options:"
-  echo "  --course1     Install Backend Client Extensions course"
-  echo "  --course2     Install Frontend Client Extensions course"
+  echo "📚 Available courses:"
+  list_course_keys
+  echo
   echo "  --help        Show this help message"
   echo
   echo "📦 Example usage:"
-  echo "  bash -c \"\$(curl -fsSL <url>)\" -- --course1 mac"
+  echo "  bash -c \"\$(curl -fsSL <url>)\" -- --pages-navigation mac"
   exit 0
 fi
 
@@ -77,7 +113,8 @@ case "$COURSE_KEY" in
     ;;
   *)
     echo "❌ Invalid course option: $COURSE_KEY"
-    echo "Use: --course1 | --course2"
+    echo "Available courses:"
+    list_course_keys
     exit 1
     ;;
 esac

--- a/course-launcher/course-setup.ps1
+++ b/course-launcher/course-setup.ps1
@@ -63,7 +63,7 @@ $_LearningPaths = @(
 # Override fallback with .conf files when running from a local checkout
 $_ScriptPath = $MyInvocation.MyCommand.Path
 if ($_ScriptPath) {
-    $_ConfDir = Join-Path (Split-Path -Parent $_ScriptPath) "course-launcher\courses"
+    $_ConfDir = Join-Path (Split-Path -Parent $_ScriptPath) "courses"
     if (Test-Path $_ConfDir) {
         $_loaded = Import-CourseConfigs -ConfDir $_ConfDir
         if ($_loaded.Count -gt 0) { $_LearningPaths = $_loaded }

--- a/course-launcher/course-setup.ps1
+++ b/course-launcher/course-setup.ps1
@@ -214,8 +214,17 @@ function Get-JavaMajorVersion {
         Write-Host "⬇️ Installing Zulu JRE inside: $JavaInstallDir"
         $zipFile = "$env:TEMP\zulu-jre.zip"
 
-        $ProgressPreference = 'SilentlyContinue' 
-        Invoke-WebRequest -Uri $ZuluDownloadUrl -OutFile $zipFile -UseBasicParsing
+        $ProgressPreference = 'SilentlyContinue'
+        try {
+            Invoke-WebRequest -Uri $ZuluDownloadUrl -OutFile $zipFile -UseBasicParsing
+        } catch {
+            Write-Host "❌ Could not download Zulu JRE."
+            Write-Host "   URL: $ZuluDownloadUrl"
+            Write-Host "   Error: $_"
+            Write-Host "   Please check your internet connection and try again."
+            Write-Host "   If the problem persists, contact support and share this message."
+            exit 1
+        }
         Expand-Archive -Path $zipFile -DestinationPath $JavaInstallDir
         Remove-Item $zipFile
 

--- a/course-launcher/course-setup.ps1
+++ b/course-launcher/course-setup.ps1
@@ -50,12 +50,12 @@ $_LearningPaths = @(
         LearningPath = "Commerce"
         Courses = @(
             "--foundations-of-commerce"
-            "--users-and-accounts"
-            "--product-management"
-            "--inventory-management"
-            "--pricing"
-            "--order-management"
-            "--storefronts"
+            "--commerce-users-and-accounts"
+            "--commerce-product-management"
+            "--commerce-inventory-management"
+            "--commerce-pricing"
+            "--commerce-order-management"
+            "--commerce-storefronts"
         )
     }
 )
@@ -110,22 +110,22 @@ function install-course {
         "--foundations-of-commerce" {
             $RepoUrl = "https://github.com/liferay/liferay-course-foundations-of-commerce/archive/refs/heads/main.zip"
         }
-        "--users-and-accounts" {
+        "--commerce-users-and-accounts" {
             $RepoUrl = "https://github.com/liferay/liferay-course-commerce-users-and-accounts/archive/refs/heads/main.zip"
         }
-        "--product-management" {
+        "--commerce-product-management" {
             $RepoUrl = "https://github.com/liferay/liferay-course-commerce-product-management/archive/refs/heads/main.zip"
         }
-        "--inventory-management" {
+        "--commerce-inventory-management" {
             $RepoUrl = "https://github.com/liferay/liferay-course-commerce-inventory-management/archive/refs/heads/main.zip"
         }
-        "--pricing" {
+        "--commerce-pricing" {
             $RepoUrl = "https://github.com/liferay/liferay-course-commerce-pricing/archive/refs/heads/main.zip"
         }
-        "--order-management" {
+        "--commerce-order-management" {
             $RepoUrl = "https://github.com/liferay/liferay-course-commerce-order-management/archive/refs/heads/main.zip"
         }
-        "--storefronts" {
+        "--commerce-storefronts" {
             $RepoUrl = "https://github.com/liferay/liferay-course-commerce-storefronts/archive/refs/heads/main.zip"
         }
         "--content-management-system" {

--- a/course-launcher/course-setup.sh
+++ b/course-launcher/course-setup.sh
@@ -18,7 +18,7 @@ declare -a _LP_COURSES=(
 
 _load_course_configs() {
   local conf_dir
-  conf_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/course-launcher/courses"
+  conf_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/courses"
   [[ -d "$conf_dir" ]] || return
   local _found=0
   for conf_file in "${conf_dir}"/*.conf; do

--- a/course-launcher/course-setup.sh
+++ b/course-launcher/course-setup.sh
@@ -13,7 +13,7 @@ declare -a _LP_NAMES=("Content Manager" "Site Building" "Commerce")
 declare -a _LP_COURSES=(
   "--publishing-tool-and-content-lifecycle --pages-navigation --search-engine-optimization --content-search --personalized-experiences --classic-cms --content-management-system"
   "--building-enterprise-websites"
-  "--foundations-of-commerce --users-and-accounts --product-management --inventory-management --pricing --order-management --storefronts"
+  "--foundations-of-commerce --commerce-users-and-accounts --commerce-product-management --commerce-inventory-management --commerce-pricing --commerce-order-management --commerce-storefronts"
 )
 
 _load_course_configs() {
@@ -96,22 +96,22 @@ case "$COURSE_KEY" in
     --foundations-of-commerce)
     REPO_URL="https://github.com/liferay/liferay-course-foundations-of-commerce/archive/refs/heads/main.zip"
     ;;
-    --users-and-accounts)
+    --commerce-users-and-accounts)
     REPO_URL="https://github.com/liferay/liferay-course-commerce-users-and-accounts/archive/refs/heads/main.zip"
     ;;
-    --product-management)
+    --commerce-product-management)
     REPO_URL="https://github.com/liferay/liferay-course-commerce-product-management/archive/refs/heads/main.zip"
     ;;
-    --inventory-management)
+    --commerce-inventory-management)
     REPO_URL="https://github.com/liferay/liferay-course-commerce-inventory-management/archive/refs/heads/main.zip"
     ;;
-    --pricing)
+    --commerce-pricing)
     REPO_URL="https://github.com/liferay/liferay-course-commerce-pricing/archive/refs/heads/main.zip"
     ;;
-    --order-management)
+    --commerce-order-management)
     REPO_URL="https://github.com/liferay/liferay-course-commerce-order-management/archive/refs/heads/main.zip"
     ;;
-    --storefronts)
+    --commerce-storefronts)
     REPO_URL="https://github.com/liferay/liferay-course-commerce-storefronts/archive/refs/heads/main.zip"
     ;;
     --content-management-system)

--- a/course-launcher/course-setup.sh
+++ b/course-launcher/course-setup.sh
@@ -190,9 +190,32 @@ install_zulu_jre() {
   [[ "$ARCH" =~ (arm64|aarch64) ]] && ARCH="aarch64"
 
   echo "🌐 Fetching Zulu JRE URL..."
-  local ZULU_URL
-  ZULU_URL=$(fetch_text "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?java_version=${JAVA_REQUIRED_VERSION}&os=${OS}&arch=${ARCH}&ext=tar.gz&bundle_type=jre&javafx=false&release_status=ga&hw_bitness=64" \
+  local ZULU_API_URL="https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?java_version=${JAVA_REQUIRED_VERSION}&os=${OS}&arch=${ARCH}&ext=tar.gz&bundle_type=jre&javafx=false&release_status=ga&hw_bitness=64"
+  local ZULU_API_RESPONSE ZULU_URL
+
+  set +e
+  ZULU_API_RESPONSE=$(fetch_text "$ZULU_API_URL")
+  local FETCH_EXIT=$?
+  set -e
+
+  if [[ $FETCH_EXIT -ne 0 ]] || [[ -z "$ZULU_API_RESPONSE" ]]; then
+    echo "❌ Could not reach the Azul API to fetch the Zulu JRE download URL."
+    echo "   Endpoint: https://api.azul.com/zulu/download/community/v1.0/bundles/latest/"
+    echo "   Please check your internet connection and try again."
+    echo "   If the problem persists, contact support and share this message."
+    exit 1
+  fi
+
+  ZULU_URL=$(echo "$ZULU_API_RESPONSE" \
     | grep -oE '"download_url"[ ]*:[ ]*"[^"]+"' | head -n 1 | cut -d '"' -f4)
+
+  if [[ -z "$ZULU_URL" ]]; then
+    echo "❌ The Azul API returned an unexpected response — no download URL found."
+    echo "   Endpoint: https://api.azul.com/zulu/download/community/v1.0/bundles/latest/"
+    echo "   The API may be temporarily unavailable or its format may have changed."
+    echo "   Please try again later. If the problem persists, contact support and share this message."
+    exit 1
+  fi
 
   echo "⬇️ Downloading Zulu JRE..."
   mkdir -p "$JAVA_DIR"

--- a/course-launcher/courses/commerce.conf
+++ b/course-launcher/courses/commerce.conf
@@ -1,0 +1,10 @@
+LEARNING_PATH="Commerce"
+COURSES=(
+  --foundations-of-commerce
+  --users-and-accounts
+  --product-management
+  --inventory-management
+  --pricing
+  --order-management
+  --storefronts
+)

--- a/course-launcher/courses/commerce.conf
+++ b/course-launcher/courses/commerce.conf
@@ -1,10 +1,10 @@
 LEARNING_PATH="Commerce"
 COURSES=(
   --foundations-of-commerce
-  --users-and-accounts
-  --product-management
-  --inventory-management
-  --pricing
-  --order-management
-  --storefronts
+  --commerce-users-and-accounts
+  --commerce-product-management
+  --commerce-inventory-management
+  --commerce-pricing
+  --commerce-order-management
+  --commerce-storefronts
 )

--- a/course-launcher/courses/content-manager.conf
+++ b/course-launcher/courses/content-manager.conf
@@ -1,0 +1,10 @@
+LEARNING_PATH="Content Manager"
+COURSES=(
+  --publishing-tool-and-content-lifecycle
+  --pages-navigation
+  --search-engine-optimization
+  --content-search
+  --personalized-experiences
+  --classic-cms
+  --content-management-system
+)

--- a/course-launcher/courses/site-building.conf
+++ b/course-launcher/courses/site-building.conf
@@ -1,0 +1,4 @@
+LEARNING_PATH="Site Building"
+COURSES=(
+  --building-enterprise-websites
+)


### PR DESCRIPTION
## Summary
This PR covers the documentation deliverables from Phase 4 of the 2026
maintenance window. It completes the contributor guide in the README and
provides the reference document for updating course lessons in the LMS.

> ⚠️ This branch is based on `feat/phase-3-refactor` (Phase 3).
> Merge order must be respected: Phase 1 → Phase 2 → Phase 3 → Phase 4.

## Changes

### ENBT-4111 · Update root README with new structure, script paths, and contributor guide

**New sections added to README.md:**

- `## Course Key Convention` — documents the naming standard
  (`key = repo name minus "liferay-course-"`) with examples from all
  three learning paths
- `## Adding a New Course` — step-by-step guide with two subsections:
  - *To an existing learning path*: real examples using content-manager.conf,
    course-setup.sh, and course-setup.ps1
  - *To a new learning path*: full example creating a Developer LP from scratch
- `## Troubleshooting` — covers the three bugs fixed in Phase 1:
  - JAVA_HOME not found after reopening terminal
  - Server fails to start with "CATALINA_HOME not defined"
  - gradle initBundle fails with checksum error

### ENBT-41110 · Course Environment Setup lessons update reference

A reference document (`ENBT-41110-course-setup-commands.md`) has been
generated with the updated commands for all 15 courses across the three
learning paths. This document will be used to update the LMS lessons
**after this PR chain is fully merged into main**.

Key changes reflected in every command:
- Linux/Mac: `content-manager-course-setup.sh` → `course-launcher/course-setup.sh`
- Windows: `content-manager-course-setup.ps1` → `course-launcher/course-setup.ps1`

6 Commerce course keys corrected (⚠️ flagged in the document):
- `--users-and-accounts` → `--commerce-users-and-accounts`
- `--product-management` → `--commerce-product-management`
- `--inventory-management` → `--commerce-inventory-management`
- `--pricing` → `--commerce-pricing`
- `--order-management` → `--commerce-order-management`
- `--storefronts` → `--commerce-storefronts`

## Testing
- [ ] README renders correctly on GitHub — all code blocks and sections display as expected
- [ ] All 3 new README sections present and in correct order
- [ ] Course setup commands validated against the .conf files — all 15 keys match

## PR chain
- Phase 1: #11 — pending merge
- Phase 2: #12 — pending Phase 1 merge
- Phase 3: #13 — pending Phase 2 merge
- Phase 4: this PR — pending Phase 3 merge