### PR TITLE
fix: repair Java 21 installation for Mac and Windows course launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Here, you'll execute the course launcher tool to prepare your system and set up 
    **Windows**:
 
    ```bash
-   .\bundles\tomcat\bin\startup.bat
+   cd bundles\tomcat\bin
+   startup.bat
    ```
 
 1. Verify the “Tomcat started“ message displays.
@@ -102,7 +103,8 @@ Here, you'll execute the course launcher tool to prepare your system and set up 
 > **Windows**:
 >
 > ```bash
-> .\bundles\tomcat\bin\shutdown.bat
+> cd bundles\tomcat\bin
+> shutdown.bat
 > ```
 
 Great! With your environment set up, you’re ready to start contributing to Clarity’s applications.

--- a/README.md
+++ b/README.md
@@ -65,11 +65,10 @@ Here, you'll execute the course launcher tool to prepare your system and set up 
    **Windows**:
 
    ```bash
-   cd bundles\tomcat\bin
-   startup.bat
+   .\bundles\tomcat\bin\startup.bat
    ```
 
-1. Verify the “Tomcat started“ message displays.
+1. Verify the “Tomcat started” message displays.
 
    This indicates that the server has initiated its startup process in the background.
 
@@ -103,8 +102,7 @@ Here, you'll execute the course launcher tool to prepare your system and set up 
 > **Windows**:
 >
 > ```bash
-> cd bundles\tomcat\bin
-> shutdown.bat
+> .\bundles\tomcat\bin\shutdown.bat
 > ```
 
 Great! With your environment set up, you’re ready to start contributing to Clarity’s applications.

--- a/content-manager-course-setup.ps1
+++ b/content-manager-course-setup.ps1
@@ -199,7 +199,8 @@ function Get-JavaMajorVersion {
     # Verify Java 21 is active before running Gradle.
     # Prefers JAVA_HOME/bin/java.exe to avoid PATH-cache issues,
     # giving a clear message instead of the cryptic JVM flag error.
-    $verifyJavaExe = if ($env:JAVA_HOME) { Join-Path $env:JAVA_HOME "bin\java.exe" } else { (Get-Command java -ErrorAction SilentlyContinue)?.Source }
+    $javaCmd = Get-Command java -ErrorAction SilentlyContinue
+    $verifyJavaExe = if ($env:JAVA_HOME) { Join-Path $env:JAVA_HOME "bin\java.exe" } elseif ($javaCmd) { $javaCmd.Source } else { $null }
     if (-not ($verifyJavaExe -and (Test-Path $verifyJavaExe))) {
         Write-Host "❌ No Java executable found after setup."
         Write-Host "   Please open a new terminal and re-run the script."

--- a/content-manager-course-setup.ps1
+++ b/content-manager-course-setup.ps1
@@ -206,7 +206,19 @@ function Get-JavaMajorVersion {
         Write-Host "   Please open a new terminal and re-run the script."
         exit 1
     }
-    $verifyOut = & $verifyJavaExe -version 2>&1 | Out-String
+    # Use Start-Process to capture java -version without triggering
+    # NativeCommandError: java writes version info to stderr, which PowerShell
+    # treats as a terminating error when $ErrorActionPreference = "Stop".
+    $tmpVerErr = [System.IO.Path]::GetTempFileName()
+    $tmpVerOut = [System.IO.Path]::GetTempFileName()
+    try {
+        Start-Process -FilePath $verifyJavaExe -ArgumentList '-version' `
+              -NoNewWindow -Wait `
+              -RedirectStandardError $tmpVerErr -RedirectStandardOutput $tmpVerOut
+        $verifyOut = (Get-Content $tmpVerOut -Raw) + "`n" + (Get-Content $tmpVerErr -Raw)
+    } finally {
+        Remove-Item $tmpVerErr,$tmpVerOut -ErrorAction SilentlyContinue
+    }
     $verifyMatch = [regex]::Match($verifyOut, 'version\s+"?(?<v>\d+(?:\.\d+)*)')
     $verifyMajor = if ($verifyMatch.Success) {
         $p = $verifyMatch.Groups['v'].Value.Split('.')

--- a/content-manager-course-setup.ps1
+++ b/content-manager-course-setup.ps1
@@ -263,16 +263,25 @@ function Get-JavaMajorVersion {
             }
         }
 
-        # Write setenv.bat so Tomcat always starts with the correct Java 21,
-        # regardless of the user's system-level JAVA_HOME.
-        # catalina.bat sources this file automatically on every startup/shutdown.
+        # Inject JAVA_HOME into setenv.bat so Tomcat always starts with the
+        # correct Java 21, regardless of the user's system-level JAVA_HOME.
+        # catalina.bat sources setenv.bat automatically on every startup/shutdown.
+        # If initBundle already created a setenv.bat (Liferay uses it for JVM
+        # heap options), prepend JAVA_HOME instead of overwriting the whole file.
         $tomcatJavaHome = if ($env:JAVA_HOME) {
             $env:JAVA_HOME
         } else {
             Split-Path (Split-Path $verifyJavaExe -Parent) -Parent
         }
+        $javahomeLine = "set `"JAVA_HOME=$tomcatJavaHome`""
         $setenvPath = Join-Path $tomcatBinDir "setenv.bat"
-        Set-Content -Path $setenvPath -Value "set `"JAVA_HOME=$tomcatJavaHome`""
+        if (Test-Path $setenvPath) {
+            $existing = Get-Content $setenvPath -Raw
+            $filtered = ($existing -split "`r?`n" | Where-Object { $_ -notmatch '^set "JAVA_HOME=' }) -join "`r`n"
+            Set-Content -Path $setenvPath -Value "$javahomeLine`r`n$filtered" -NoNewline
+        } else {
+            Set-Content -Path $setenvPath -Value $javahomeLine
+        }
         Write-Host "🔧 Configured Tomcat to use JAVA_HOME=$tomcatJavaHome"
     }
 

--- a/content-manager-course-setup.ps1
+++ b/content-manager-course-setup.ps1
@@ -241,6 +241,29 @@ function Get-JavaMajorVersion {
             Write-Host "❌ Gradle failed with exit code $($p.ExitCode)"
             exit $p.ExitCode
         }
+
+    # Patch Tomcat's startup.bat and shutdown.bat to use %~dp0.. (the script's
+    # own directory) instead of %cd% (the caller's working directory) for
+    # CATALINA_HOME detection. Without this, running them via a relative path
+    # (e.g. .\bundles\tomcat\bin\startup.bat from the course root) fails with
+    # "CATALINA_HOME is not defined correctly".
+    $tomcatBinDir = Get-ChildItem -Path (Join-Path $ExtractPath "bundles") -Recurse `
+        -Filter "startup.bat" -ErrorAction SilentlyContinue |
+        Select-Object -First 1 -ExpandProperty DirectoryName
+    if ($tomcatBinDir) {
+        foreach ($bat in @("startup.bat", "shutdown.bat")) {
+            $batPath = Join-Path $tomcatBinDir $bat
+            if (Test-Path $batPath) {
+                $original = Get-Content $batPath -Raw
+                $patched  = $original -replace 'set "CATALINA_HOME=%CURRENT_DIR%"', 'set "CATALINA_HOME=%~dp0.."'
+                if ($original -ne $patched) {
+                    Set-Content -Path $batPath -Value $patched -NoNewline
+                    Write-Host "🔧 Patched $bat for script-relative CATALINA_HOME."
+                }
+            }
+        }
+    }
+
     Write-Host "✅ Done. Liferay bundle initialized. You may proceed to start your Liferay application now."
 return
 }

--- a/content-manager-course-setup.ps1
+++ b/content-manager-course-setup.ps1
@@ -273,16 +273,18 @@ function Get-JavaMajorVersion {
         } else {
             Split-Path (Split-Path $verifyJavaExe -Parent) -Parent
         }
-        $javahomeLine = "set `"JAVA_HOME=$tomcatJavaHome`""
+        # Write absolute paths for both JAVA_HOME and JRE_HOME.
+        # Tomcat checks JRE_HOME first; without it, catalina.bat may resolve
+        # to the system Java instead of our managed JRE 21.
+        $javaHomeLine = "set `"JAVA_HOME=$tomcatJavaHome`""
+        $jreHomeLine  = "set `"JRE_HOME=$tomcatJavaHome`""
         $setenvPath = Join-Path $tomcatBinDir "setenv.bat"
-        if (Test-Path $setenvPath) {
-            $existing = Get-Content $setenvPath -Raw
-            $filtered = ($existing -split "`r?`n" | Where-Object { $_ -notmatch '^set "JAVA_HOME=' }) -join "`r`n"
-            Set-Content -Path $setenvPath -Value "$javahomeLine`r`n$filtered" -NoNewline
-        } else {
-            Set-Content -Path $setenvPath -Value $javahomeLine
-        }
-        Write-Host "🔧 Configured Tomcat to use JAVA_HOME=$tomcatJavaHome"
+        $existing = if (Test-Path $setenvPath) { Get-Content $setenvPath -Raw } else { "" }
+        $filtered = ($existing -split "`r?`n" |
+            Where-Object { $_ -notmatch '^set "JAVA_HOME=' -and $_ -notmatch '^set "JRE_HOME=' }) -join "`r`n"
+        $newContent = "$javaHomeLine`r`n$jreHomeLine`r`n$filtered".TrimEnd()
+        Set-Content -Path $setenvPath -Value $newContent -NoNewline
+        Write-Host "🔧 Configured Tomcat to use Java 21 (JAVA_HOME=$tomcatJavaHome)"
     }
 
     Write-Host "✅ Done. Liferay bundle initialized. You may proceed to start your Liferay application now."

--- a/content-manager-course-setup.ps1
+++ b/content-manager-course-setup.ps1
@@ -262,6 +262,18 @@ function Get-JavaMajorVersion {
                 }
             }
         }
+
+        # Write setenv.bat so Tomcat always starts with the correct Java 21,
+        # regardless of the user's system-level JAVA_HOME.
+        # catalina.bat sources this file automatically on every startup/shutdown.
+        $tomcatJavaHome = if ($env:JAVA_HOME) {
+            $env:JAVA_HOME
+        } else {
+            Split-Path (Split-Path $verifyJavaExe -Parent) -Parent
+        }
+        $setenvPath = Join-Path $tomcatBinDir "setenv.bat"
+        Set-Content -Path $setenvPath -Value "set `"JAVA_HOME=$tomcatJavaHome`""
+        Write-Host "🔧 Configured Tomcat to use JAVA_HOME=$tomcatJavaHome"
     }
 
     Write-Host "✅ Done. Liferay bundle initialized. You may proceed to start your Liferay application now."

--- a/content-manager-course-setup.ps1
+++ b/content-manager-course-setup.ps1
@@ -8,6 +8,12 @@ function install-course {
     # === CONFIGURATION ===
     $JavaRequiredVersion = 21
     $ZuluDownloadUrl = "https://cdn.azul.com/zulu/bin/zulu21.30.15-ca-jre21.0.1-win_x64.zip"
+    # Managed JRE lives in a stable, user-level directory (mirrors the shell
+    # script's ${HOME}/.liferay-course-runtime/zulu-java-21 path).
+    # A fixed path lets setenv.bat reference %USERPROFILE% instead of an
+    # absolute path that only works for the user who ran the installer.
+    $RuntimeDir    = "$env:USERPROFILE\.liferay-course-runtime"
+    $JavaInstallDir = "$RuntimeDir\zulu-java-21"
 
     switch ($CourseKey) {
         "--publishing-tool-and-content-lifecycle" {
@@ -128,12 +134,11 @@ function Get-JavaMajorVersion {
     return [int]$parts[0]
 }
 
-    # === Java Installation Inside the Extracted Folder ===
-    $JavaInstallDir = Join-Path $ExtractPath "zulu-java"
+    # === Java Installation (user-level, shared across all courses) ===
     $JavaMarkerFile = Join-Path $JavaInstallDir ".installed"
 
     function Install-ZuluJRE {
-        Write-Host "⬇️ Installing Zulu JRE inside: $JavaInstallDir"
+        Write-Host "⬇️ Installing Zulu JRE to: $JavaInstallDir"
         $zipFile = "$env:TEMP\zulu-jre.zip"
 
         $ProgressPreference = 'SilentlyContinue'
@@ -147,31 +152,38 @@ function Get-JavaMajorVersion {
             Write-Host "   If the problem persists, contact support and share this message."
             exit 1
         }
-        Expand-Archive -Path $zipFile -DestinationPath $JavaInstallDir
+
+        # Extract to a temp dir first, then move the versioned subdirectory's
+        # contents into the stable $JavaInstallDir so the path never changes
+        # even if the Zulu version number is updated later.
+        $tmpExtract = Join-Path $env:TEMP "zulu-extract-tmp"
+        if (Test-Path $tmpExtract) { Remove-Item $tmpExtract -Recurse -Force }
+        Expand-Archive -Path $zipFile -DestinationPath $tmpExtract
         Remove-Item $zipFile
+        $unzipped = Get-ChildItem $tmpExtract | Where-Object { $_.PsIsContainer } | Select-Object -First 1
+        New-Item -ItemType Directory -Path $JavaInstallDir -Force | Out-Null
+        Move-Item -Path (Join-Path $unzipped.FullName "*") -Destination $JavaInstallDir -Force
+        Remove-Item $tmpExtract -Recurse -Force
 
-        $unzipped = Get-ChildItem $JavaInstallDir | Where-Object { $_.PsIsContainer } | Select-Object -First 1
-        $ZuluPath = $unzipped.FullName
-
-        $env:JAVA_HOME = $ZuluPath
-        $env:Path = "$ZuluPath\bin;$env:Path"
+        $env:JAVA_HOME = $JavaInstallDir
+        $env:Path = "$JavaInstallDir\bin;$env:Path"
 
         New-Item $JavaMarkerFile -ItemType File | Out-Null
-        Write-Host "✅ Java installed at $ZuluPath"
+        Write-Host "✅ Java installed at $JavaInstallDir"
         java -version
 
         # Persist JAVA_HOME for future sessions.
         # We compare against our exact path so that an existing Java 8 entry
         # is overwritten — not silently skipped.
         $existingJavaHome = [System.Environment]::GetEnvironmentVariable("JAVA_HOME", [System.EnvironmentVariableTarget]::User)
-        if ($existingJavaHome -ne $ZuluPath) {
-            [System.Environment]::SetEnvironmentVariable("JAVA_HOME", $ZuluPath, [System.EnvironmentVariableTarget]::User)
-            Write-Host "📝 JAVA_HOME updated to $ZuluPath in user environment."
+        if ($existingJavaHome -ne $JavaInstallDir) {
+            [System.Environment]::SetEnvironmentVariable("JAVA_HOME", $JavaInstallDir, [System.EnvironmentVariableTarget]::User)
+            Write-Host "📝 JAVA_HOME updated to $JavaInstallDir in user environment."
         } else {
             Write-Host "ℹ️  JAVA_HOME already correctly set, skipping."
         }
         $userPath = [System.Environment]::GetEnvironmentVariable("PATH", [System.EnvironmentVariableTarget]::User)
-        $zuluBin = "$ZuluPath\bin"
+        $zuluBin = "$JavaInstallDir\bin"
         if ($userPath -notlike "*$zuluBin*") {
             [System.Environment]::SetEnvironmentVariable("PATH", "$zuluBin;$userPath", [System.EnvironmentVariableTarget]::User)
             Write-Host "📝 $zuluBin added to user PATH."
@@ -185,10 +197,9 @@ function Get-JavaMajorVersion {
 
     if ($javaMajor -ne $JavaRequiredVersion) {
         if (Test-Path $JavaMarkerFile) {
-            Write-Host "☕ Using previously installed Java inside $JavaInstallDir"
-            $ZuluPath = (Get-ChildItem $JavaInstallDir | Where-Object { $_.PsIsContainer } | Select-Object -First 1).FullName
-            $env:JAVA_HOME = $ZuluPath
-            $env:Path = "$ZuluPath\bin;$env:Path"
+            Write-Host "☕ Using previously installed Java at $JavaInstallDir"
+            $env:JAVA_HOME = $JavaInstallDir
+            $env:Path = "$JavaInstallDir\bin;$env:Path"
         } else {
             Install-ZuluJRE
         }
@@ -268,23 +279,19 @@ function Get-JavaMajorVersion {
         # catalina.bat sources setenv.bat automatically on every startup/shutdown.
         # If initBundle already created a setenv.bat (Liferay uses it for JVM
         # heap options), prepend JAVA_HOME instead of overwriting the whole file.
-        $tomcatJavaHome = if ($env:JAVA_HOME) {
-            $env:JAVA_HOME
-        } else {
-            Split-Path (Split-Path $verifyJavaExe -Parent) -Parent
-        }
-        # Write absolute paths for both JAVA_HOME and JRE_HOME.
+        # Use %USERPROFILE% (evaluated at Tomcat start time) instead of an
+        # absolute path so the file works for any user on any machine.
         # Tomcat checks JRE_HOME first; without it, catalina.bat may resolve
         # to the system Java instead of our managed JRE 21.
-        $javaHomeLine = "set `"JAVA_HOME=$tomcatJavaHome`""
-        $jreHomeLine  = "set `"JRE_HOME=$tomcatJavaHome`""
+        $javaHomeLine = 'set "JAVA_HOME=%USERPROFILE%\.liferay-course-runtime\zulu-java-21"'
+        $jreHomeLine  = 'set "JRE_HOME=%USERPROFILE%\.liferay-course-runtime\zulu-java-21"'
         $setenvPath = Join-Path $tomcatBinDir "setenv.bat"
         $existing = if (Test-Path $setenvPath) { Get-Content $setenvPath -Raw } else { "" }
         $filtered = ($existing -split "`r?`n" |
             Where-Object { $_ -notmatch '^set "JAVA_HOME=' -and $_ -notmatch '^set "JRE_HOME=' }) -join "`r`n"
         $newContent = "$javaHomeLine`r`n$jreHomeLine`r`n$filtered".TrimEnd()
         Set-Content -Path $setenvPath -Value $newContent -NoNewline
-        Write-Host "🔧 Configured Tomcat to use Java 21 (JAVA_HOME=$tomcatJavaHome)"
+        Write-Host "🔧 Configured Tomcat to use Java 21 via %USERPROFILE%\.liferay-course-runtime\zulu-java-21"
     }
 
     Write-Host "✅ Done. Liferay bundle initialized. You may proceed to start your Liferay application now."

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -234,8 +234,11 @@ persist_java_env() {
     printf 'export JAVA_HOME="${HOME}/.liferay-course-runtime/zulu-java-21"\n'
     printf 'export PATH="$JAVA_HOME/bin:$PATH"\n'
   } >> "$RC"
+  echo ""
   echo "📝 JAVA_HOME configured in $RC"
-  echo "ℹ️  Run 'source $RC' or open a new terminal for the changes to take effect."
+  echo "   To apply in this terminal, run:"
+  echo "     source $RC"
+  echo "   Or simply open a new terminal — it will already use Java 21."
 }
 
 use_or_install_java() {

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -299,15 +299,19 @@ _TOMCAT_STARTUP=$(find bundles -maxdepth 4 -name "startup.sh" 2>/dev/null | head
 if [[ -n "$_TOMCAT_STARTUP" ]]; then
   _TOMCAT_BIN=$(dirname "$_TOMCAT_STARTUP")
   _SETENV="${_TOMCAT_BIN}/setenv.sh"
-  # Write absolute paths for both JAVA_HOME and JRE_HOME.
+  # Write ${HOME}-relative paths for both JAVA_HOME and JRE_HOME so that
+  # setenv.sh works for any user, not just the one who ran the installer.
   # Tomcat checks JRE_HOME first; if unset on macOS it falls back to
   # /usr/libexec/java_home which returns the system Java 8.
-  # Using the literal path (not a shell variable reference) ensures the
-  # value is correct even before the shell environment is fully loaded.
+  # The single-quoted heredoc (<<'SETENV_JAVA') prevents ${HOME} from being
+  # expanded now — the literal text is written into setenv.sh and expanded
+  # by the shell when Tomcat sources the file at startup/shutdown.
   _TMP=$(mktemp)
   {
-    printf 'export JAVA_HOME="%s"\n' "$JAVA_HOME"
-    printf 'export JRE_HOME="%s"\n'  "$JAVA_HOME"
+    cat <<'SETENV_JAVA'
+export JAVA_HOME="${HOME}/.liferay-course-runtime/zulu-java-21"
+export JRE_HOME="${HOME}/.liferay-course-runtime/zulu-java-21"
+SETENV_JAVA
     if [[ -f "$_SETENV" ]]; then
       grep -v '^export JAVA_HOME=' "$_SETENV" \
         | grep -v '^export JRE_HOME=' \

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -280,10 +280,15 @@ echo "🛠 Setting up course environment..."
 chmod +x ./gradlew || true
 ./gradlew initBundle
 
-echo "✅ Done. Liferay bundle initialized."
-echo ""
-echo "⚠️  IMPORTANT: Before starting Liferay, open a new terminal or run:"
-echo "      source ~/.zshrc    # zsh (default on macOS)"
-echo "      source ~/.bashrc   # bash (default on Linux)"
-echo "   This is required so that JAVA_HOME takes effect in your session."
-echo "   Starting Liferay from this terminal without doing so may cause JVM errors."
+# Write setenv.sh into Tomcat's bin/ so JAVA_HOME is set before the JVM
+# starts, regardless of the user's shell environment or RC file loading.
+# catalina.sh sources this file automatically on every startup/shutdown.
+_TOMCAT_STARTUP=$(find bundles -maxdepth 4 -name "startup.sh" 2>/dev/null | head -n1)
+if [[ -n "$_TOMCAT_STARTUP" ]]; then
+  _TOMCAT_BIN=$(dirname "$_TOMCAT_STARTUP")
+  printf 'export JAVA_HOME="%s"\n' "$JAVA_HOME" > "${_TOMCAT_BIN}/setenv.sh"
+  chmod +x "${_TOMCAT_BIN}/setenv.sh"
+  echo "🔧 Configured Tomcat to use JAVA_HOME=$JAVA_HOME"
+fi
+
+echo "✅ Done. Liferay bundle initialized. You may now start your Liferay application."

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -200,17 +200,42 @@ install_zulu_jre() {
   echo "✅ Java installed at $JAVA_HOME"
   "$JAVA_HOME/bin/java" -version
 
-  # Persist JAVA_HOME and PATH update for future sessions.
-  # We check for our exact path, not just any JAVA_HOME, so that an existing
-  # Java 8 entry in the file does not prevent writing — our entry appended
-  # last takes precedence on the next shell load.
-  for RC in "${HOME}/.bashrc" "${HOME}/.zshrc" "${HOME}/.profile"; do
-    if [[ -f "$RC" ]] && ! grep -qF "JAVA_HOME=\"$JAVA_HOME\"" "$RC"; then
-      printf '\nexport JAVA_HOME="%s"\nexport PATH="$JAVA_HOME/bin:$PATH"\n' "$JAVA_HOME" >> "$RC"
-      echo "📝 Updated JAVA_HOME in $RC"
-    fi
-  done
-  echo "ℹ️  Open a new terminal or run 'source ~/.bashrc' (or ~/.zshrc) for the PATH changes to take effect."
+  persist_java_env
+}
+
+# Write JAVA_HOME persistently to the shell RC file so every new terminal
+# session picks up Java 21 automatically — same behaviour as the Windows
+# installer's SetEnvironmentVariable(User) call.
+# Idempotent: removes any previous entry we wrote (detected by our stable
+# marker path) before re-appending, so re-runs never accumulate duplicates.
+persist_java_env() {
+  # Target the canonical RC file for this OS; create it if absent.
+  if [[ "$OS" == "mac" ]]; then
+    local RC="${HOME}/.zshrc"
+  else
+    local RC="${HOME}/.bashrc"
+  fi
+
+  local MARKER=".liferay-course-runtime/zulu-java-21"
+
+  # Remove any line from a previous run that references our managed JRE path.
+  if grep -qF "$MARKER" "$RC" 2>/dev/null; then
+    local _tmp_rc
+    _tmp_rc=$(mktemp)
+    grep -vF "$MARKER" "$RC" > "$_tmp_rc" || true
+    mv "$_tmp_rc" "$RC"
+  fi
+
+  # Append a fresh entry. ${HOME} and $JAVA_HOME are written as literal text
+  # (single-quoted printf) so the RC file is portable for any username — the
+  # shell expands them when it sources the file on each new terminal session.
+  {
+    printf '\n# Added by Liferay Course Launcher\n'
+    printf 'export JAVA_HOME="${HOME}/.liferay-course-runtime/zulu-java-21"\n'
+    printf 'export PATH="$JAVA_HOME/bin:$PATH"\n'
+  } >> "$RC"
+  echo "📝 JAVA_HOME configured in $RC"
+  echo "ℹ️  Run 'source $RC' or open a new terminal for the changes to take effect."
 }
 
 use_or_install_java() {
@@ -218,6 +243,10 @@ use_or_install_java() {
   if [[ -x "$JAVA_DIR/bin/java" ]]; then
     export JAVA_HOME="$JAVA_DIR"
     export PATH="$JAVA_HOME/bin:$PATH"
+    # Ensure the RC file is up to date even when Java was installed by a
+    # previous run (e.g., the entry may be missing if the first run used an
+    # older script version that only wrote to files that already existed).
+    persist_java_env
     return
   fi
 

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -299,16 +299,24 @@ _TOMCAT_STARTUP=$(find bundles -maxdepth 4 -name "startup.sh" 2>/dev/null | head
 if [[ -n "$_TOMCAT_STARTUP" ]]; then
   _TOMCAT_BIN=$(dirname "$_TOMCAT_STARTUP")
   _SETENV="${_TOMCAT_BIN}/setenv.sh"
-  if [[ -f "$_SETENV" ]]; then
-    _TMP=$(mktemp)
-    printf 'export JAVA_HOME="%s"\n' "$JAVA_HOME" > "$_TMP"
-    grep -v '^export JAVA_HOME=' "$_SETENV" >> "$_TMP" || true
-    mv "$_TMP" "$_SETENV"
-  else
-    printf 'export JAVA_HOME="%s"\n' "$JAVA_HOME" > "$_SETENV"
-    chmod +x "$_SETENV"
-  fi
-  echo "🔧 Configured Tomcat to use JAVA_HOME=$JAVA_HOME"
+  # Write absolute paths for both JAVA_HOME and JRE_HOME.
+  # Tomcat checks JRE_HOME first; if unset on macOS it falls back to
+  # /usr/libexec/java_home which returns the system Java 8.
+  # Using the literal path (not a shell variable reference) ensures the
+  # value is correct even before the shell environment is fully loaded.
+  _TMP=$(mktemp)
+  {
+    printf 'export JAVA_HOME="%s"\n' "$JAVA_HOME"
+    printf 'export JRE_HOME="%s"\n'  "$JAVA_HOME"
+    if [[ -f "$_SETENV" ]]; then
+      grep -v '^export JAVA_HOME=' "$_SETENV" \
+        | grep -v '^export JRE_HOME=' \
+        || true
+    fi
+  } > "$_TMP"
+  mv "$_TMP" "$_SETENV"
+  chmod +x "$_SETENV"
+  echo "🔧 Configured Tomcat to use Java 21 (JAVA_HOME=$JAVA_HOME)"
 fi
 
 echo "✅ Done. Liferay bundle initialized. You may now start your Liferay application."

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -147,7 +147,10 @@ install_zulu_jre() {
   [[ "$ARCH" =~ (arm64|aarch64) ]] && ARCH="aarch64"
 
   echo "🌐 Fetching Zulu JRE URL..."
-  local ZULU_API_URL="https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?java_version=${JAVA_REQUIRED_VERSION}&os=${OS}&arch=${ARCH}&ext=tar.gz&bundle_type=jre&javafx=false&release_status=ga&hw_bitness=64"
+  # The Azul API expects 'macos', not 'mac'
+  local AZUL_OS="${OS}"
+  [[ "$AZUL_OS" == "mac" ]] && AZUL_OS="macos"
+  local ZULU_API_URL="https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?java_version=${JAVA_REQUIRED_VERSION}&os=${AZUL_OS}&arch=${ARCH}&ext=tar.gz&bundle_type=jre&javafx=false&release_status=ga&hw_bitness=64"
   local ZULU_API_RESPONSE ZULU_URL
 
   set +e
@@ -208,21 +211,11 @@ use_or_install_java() {
     return
   fi
 
-  # Else, check system Java and version
-  if check_command java; then
-    local VER
-    VER=$(java -version 2>&1 | head -n1 | grep -oE '"[0-9]+' | tr -d '"')
-    if [[ "$VER" == "21" ]]; then
-      # Use system Java 21
-      return
-    fi
-  fi
-
-  # Else, install our managed JRE 21
+  # Install managed JRE — ensures JAVA_HOME is always explicitly set and
+  # persisted to RC files regardless of any system Java that may be present.
+  # Relying on an unmanaged system Java risks JAVA_HOME being unset when
+  # Tomcat starts in a new terminal, causing cryptic JVM flag errors.
   install_zulu_jre
-  # Defensive re-assertion: install_zulu_jre already exports these, but
-  # repeating here guarantees the caller sees the correct values regardless
-  # of any shell scoping edge case.
   export JAVA_HOME="$JAVA_DIR"
   export PATH="$JAVA_HOME/bin:$PATH"
 }
@@ -287,4 +280,10 @@ echo "🛠 Setting up course environment..."
 chmod +x ./gradlew || true
 ./gradlew initBundle
 
-echo "✅ Done. Liferay bundle initialized. You may proceed to start your Liferay application now."
+echo "✅ Done. Liferay bundle initialized."
+echo ""
+echo "⚠️  IMPORTANT: Before starting Liferay, open a new terminal or run:"
+echo "      source ~/.zshrc    # zsh (default on macOS)"
+echo "      source ~/.bashrc   # bash (default on Linux)"
+echo "   This is required so that JAVA_HOME takes effect in your session."
+echo "   Starting Liferay from this terminal without doing so may cause JVM errors."

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -1,6 +1,16 @@
 #!/bin/bash
 set -e
 
+# Guard: if the current directory is no longer accessible (e.g., a previous
+# run renamed or deleted it), bash cannot create subshells and the getcwd
+# error becomes the first line of any pipeline output, breaking version checks.
+# pwd is a shell builtin — it calls getcwd() without spawning a subprocess.
+if ! pwd > /dev/null 2>&1; then
+  echo "❌ Your current directory is no longer accessible."
+  echo "   Please open a new terminal and re-run the command from a valid directory."
+  exit 1
+fi
+
 # === CONSTANTS ===
 JAVA_REQUIRED_VERSION="21.0.1"
 RUNTIME_DIR="${HOME}/.liferay-course-runtime"
@@ -292,7 +302,7 @@ if [[ -n "$_TOMCAT_STARTUP" ]]; then
   if [[ -f "$_SETENV" ]]; then
     _TMP=$(mktemp)
     printf 'export JAVA_HOME="%s"\n' "$JAVA_HOME" > "$_TMP"
-    grep -v '^export JAVA_HOME=' "$_SETENV" >> "$_TMP"
+    grep -v '^export JAVA_HOME=' "$_SETENV" >> "$_TMP" || true
     mv "$_TMP" "$_SETENV"
   else
     printf 'export JAVA_HOME="%s"\n' "$JAVA_HOME" > "$_SETENV"

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -280,14 +280,24 @@ echo "🛠 Setting up course environment..."
 chmod +x ./gradlew || true
 ./gradlew initBundle
 
-# Write setenv.sh into Tomcat's bin/ so JAVA_HOME is set before the JVM
-# starts, regardless of the user's shell environment or RC file loading.
-# catalina.sh sources this file automatically on every startup/shutdown.
+# Inject JAVA_HOME into Tomcat's setenv.sh so the server always starts with
+# Java 21, regardless of the user's shell environment or RC file loading.
+# catalina.sh sources setenv.sh automatically on every startup/shutdown.
+# If initBundle already created a setenv.sh (Liferay uses it for JVM heap
+# options), we prepend JAVA_HOME instead of overwriting the whole file.
 _TOMCAT_STARTUP=$(find bundles -maxdepth 4 -name "startup.sh" 2>/dev/null | head -n1)
 if [[ -n "$_TOMCAT_STARTUP" ]]; then
   _TOMCAT_BIN=$(dirname "$_TOMCAT_STARTUP")
-  printf 'export JAVA_HOME="%s"\n' "$JAVA_HOME" > "${_TOMCAT_BIN}/setenv.sh"
-  chmod +x "${_TOMCAT_BIN}/setenv.sh"
+  _SETENV="${_TOMCAT_BIN}/setenv.sh"
+  if [[ -f "$_SETENV" ]]; then
+    _TMP=$(mktemp)
+    printf 'export JAVA_HOME="%s"\n' "$JAVA_HOME" > "$_TMP"
+    grep -v '^export JAVA_HOME=' "$_SETENV" >> "$_TMP"
+    mv "$_TMP" "$_SETENV"
+  else
+    printf 'export JAVA_HOME="%s"\n' "$JAVA_HOME" > "$_SETENV"
+    chmod +x "$_SETENV"
+  fi
   echo "🔧 Configured Tomcat to use JAVA_HOME=$JAVA_HOME"
 fi
 


### PR DESCRIPTION
Windows: replace PS7-only null-conditional operator ?.Source (line 202 of .ps1) with a PS5.x-compatible two-step null check so the script parses correctly on Windows PowerShell 5.x.

Mac: the Azul download API rejects 'os=mac'; map it to 'os=macos' before building the API URL so the JRE download URL is returned correctly.

Mac/Linux: remove the 'system Java 21' early-return in use_or_install_java that left JAVA_HOME unset. Without JAVA_HOME, Tomcat falls back to the system Java (e.g. Java 8) and fails with the cryptic --add-opens error. The managed JRE is now always installed when absent, ensuring JAVA_HOME is both exported in-session and persisted to shell RC files.

Also: improve the completion message to explicitly warn users to open a new terminal (or source their RC file) before starting Liferay.