### PR TITLE
fix: skip Java install/persist when system Java 21 is already present

### DIFF
--- a/content-manager-course-setup.ps1
+++ b/content-manager-course-setup.ps1
@@ -7,7 +7,7 @@ function install-course {
 
     # === CONFIGURATION ===
     $JavaRequiredVersion = 21
-    $ZuluDownloadUrl = "https://cdn.azul.com/zulu/bin/zulu21.30.15-ca-jre21.0.1-win_x64.zip"
+    $ZuluDownloadUrl = "https://cdn.azul.com/zulu/bin/zulu21.52.15-ca-jre21.0.12-win_x64.zip"
     # Managed JRE lives in a stable, user-level directory (mirrors the shell
     # script's ${HOME}/.liferay-course-runtime/zulu-java-21 path).
     # A fixed path lets setenv.bat reference %USERPROFILE% instead of an
@@ -68,29 +68,6 @@ function install-course {
     }
 
     $ZipPath = "$env:TEMP\course.zip"
-
-    # === Download ZIP ===
-    Write-Host "📦 Downloading course repository..."
-    $ProgressPreference = 'SilentlyContinue' 
-    Invoke-WebRequest -Uri $RepoUrl -OutFile $ZipPath -UseBasicParsing
-
-    # === Extract ZIP directly here ===
-    Write-Host "📂 Extracting ZIP to current folder..."
-    Expand-Archive -Path $ZipPath -DestinationPath $PWD -Force
-    Remove-Item $ZipPath
-
-    # === Find the extracted folder name ===
-    $ExtractedFolder = Get-ChildItem -Path $PWD | Where-Object {
-        $_.PsIsContainer -and $_.Name -like "liferay-course-*"
-    } | Sort-Object LastWriteTime -Descending | Select-Object -First 1
-
-    if ($null -eq $ExtractedFolder) {
-        Write-Host "❌ Could not find the extracted folder."
-        exit 1
-    }
-
-    $ExtractPath = $ExtractedFolder.FullName
-    Write-Host "📁 Using extracted folder: $ExtractPath"
 
     # === Java Detection ===
 function Get-JavaMajorVersion {
@@ -252,6 +229,29 @@ function Get-JavaMajorVersion {
         Write-Host "   If Java $JavaRequiredVersion was just installed, open a new terminal and re-run the script."
         exit 1
     }
+
+    # === Download ZIP ===
+    Write-Host "📦 Downloading course repository..."
+    $ProgressPreference = 'SilentlyContinue'
+    Invoke-WebRequest -Uri $RepoUrl -OutFile $ZipPath -UseBasicParsing
+
+    # === Extract ZIP directly here ===
+    Write-Host "📂 Extracting ZIP to current folder..."
+    Expand-Archive -Path $ZipPath -DestinationPath $PWD -Force
+    Remove-Item $ZipPath
+
+    # === Find the extracted folder name ===
+    $ExtractedFolder = Get-ChildItem -Path $PWD | Where-Object {
+        $_.PsIsContainer -and $_.Name -like "liferay-course-*"
+    } | Sort-Object LastWriteTime -Descending | Select-Object -First 1
+
+    if ($null -eq $ExtractedFolder) {
+        Write-Host "❌ Could not find the extracted folder."
+        exit 1
+    }
+
+    $ExtractPath = $ExtractedFolder.FullName
+    Write-Host "📁 Using extracted folder: $ExtractPath"
 
     # === Run Gradle Init ===
     Set-Location $ExtractPath

--- a/content-manager-course-setup.ps1
+++ b/content-manager-course-setup.ps1
@@ -194,17 +194,27 @@ function Get-JavaMajorVersion {
     }
 
     $javaMajor = Get-JavaMajorVersion
+    $usingManagedJRE = $false
 
     if ($javaMajor -ne $JavaRequiredVersion) {
         if (Test-Path $JavaMarkerFile) {
             Write-Host "☕ Using previously installed Java at $JavaInstallDir"
             $env:JAVA_HOME = $JavaInstallDir
             $env:Path = "$JavaInstallDir\bin;$env:Path"
+            $usingManagedJRE = $true
         } else {
             Install-ZuluJRE
+            $usingManagedJRE = $true
         }
     } else {
         Write-Host "☕ System Java version $javaMajor is OK."
+        # Resolve JAVA_HOME from the system java binary so the setenv.bat
+        # injection below can point Tomcat at the real install, not the
+        # managed-JRE path (which doesn't exist when the system Java is used).
+        try {
+            $sysJavaCmd = (Get-Command java -ErrorAction Stop).Source
+            $env:JAVA_HOME = Split-Path (Split-Path $sysJavaCmd -Parent) -Parent
+        } catch { }
     }
 
     # Verify Java 21 is active before running Gradle.
@@ -283,15 +293,27 @@ function Get-JavaMajorVersion {
         # absolute path so the file works for any user on any machine.
         # Tomcat checks JRE_HOME first; without it, catalina.bat may resolve
         # to the system Java instead of our managed JRE 21.
-        $javaHomeLine = 'set "JAVA_HOME=%USERPROFILE%\.liferay-course-runtime\zulu-java-21"'
-        $jreHomeLine  = 'set "JRE_HOME=%USERPROFILE%\.liferay-course-runtime\zulu-java-21"'
+        if ($usingManagedJRE) {
+            # Managed JRE: write %USERPROFILE%-relative paths so setenv.bat
+            # works for any user, not just the one who ran the installer.
+            $javaHomeLine = 'set "JAVA_HOME=%USERPROFILE%\.liferay-course-runtime\zulu-java-21"'
+            $jreHomeLine  = 'set "JRE_HOME=%USERPROFILE%\.liferay-course-runtime\zulu-java-21"'
+            $tomcatJavaNote = "%USERPROFILE%\.liferay-course-runtime\zulu-java-21"
+        } else {
+            # System Java 21 is being used (left in place) — point Tomcat at
+            # its actual resolved path, not the managed-JRE path (which doesn't
+            # exist when the system Java was used instead).
+            $javaHomeLine = "set `"JAVA_HOME=$($env:JAVA_HOME)`""
+            $jreHomeLine  = "set `"JRE_HOME=$($env:JAVA_HOME)`""
+            $tomcatJavaNote = $env:JAVA_HOME
+        }
         $setenvPath = Join-Path $tomcatBinDir "setenv.bat"
         $existing = if (Test-Path $setenvPath) { Get-Content $setenvPath -Raw } else { "" }
         $filtered = ($existing -split "`r?`n" |
             Where-Object { $_ -notmatch '^set "JAVA_HOME=' -and $_ -notmatch '^set "JRE_HOME=' }) -join "`r`n"
         $newContent = "$javaHomeLine`r`n$jreHomeLine`r`n$filtered".TrimEnd()
         Set-Content -Path $setenvPath -Value $newContent -NoNewline
-        Write-Host "🔧 Configured Tomcat to use Java 21 via %USERPROFILE%\.liferay-course-runtime\zulu-java-21"
+        Write-Host "🔧 Configured Tomcat to use Java 21 via $tomcatJavaNote"
     }
 
     Write-Host "✅ Done. Liferay bundle initialized. You may proceed to start your Liferay application now."

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -12,7 +12,7 @@ if ! pwd > /dev/null 2>&1; then
 fi
 
 # === CONSTANTS ===
-JAVA_REQUIRED_VERSION="21.0.1"
+JAVA_REQUIRED_VERSION="21.0.12"
 RUNTIME_DIR="${HOME}/.liferay-course-runtime"
 JAVA_DIR="${RUNTIME_DIR}/zulu-java-21"
 

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -241,6 +241,50 @@ persist_java_env() {
   echo "   Or simply open a new terminal — it will already use Java 21."
 }
 
+# Returns the major version (e.g. "21") of the given java binary on stdout,
+# or nothing if it can't be determined. Handles both modern version strings
+# ("21.0.11" -> 21) and legacy 1.x strings ("1.8.0_411" -> 8). Mirrors
+# Get-JavaMajorVersion in content-manager-course-setup.ps1, which already
+# gets this right on Windows.
+get_java_major_version() {
+  local java_bin="$1"
+  [[ -x "$java_bin" ]] || return 1
+  local out ver major
+  out=$("$java_bin" -version 2>&1)
+  ver=$(echo "$out" | grep -oE '"[0-9]+(\.[0-9]+)*' | head -n1 | tr -d '"')
+  [[ -z "$ver" ]] && ver=$(echo "$out" | grep -oiE '^\s*openjdk\s+[0-9]+(\.[0-9]+)*' | head -n1 | grep -oE '[0-9]+(\.[0-9]+)*')
+  [[ -z "$ver" ]] && return 1
+  major="${ver%%.*}"
+  if [[ "$major" == "1" ]]; then
+    major=$(echo "$ver" | cut -d. -f2)
+  fi
+  echo "$major"
+}
+
+# Best-effort JAVA_HOME for an already-installed system java binary, so that
+# later steps (e.g. writing Tomcat's setenv.sh) point at the real install
+# instead of guessing. Uses `/usr/libexec/java_home` on mac (the canonical
+# way to resolve a specific version there) and resolves symlinks on Linux
+# (java is commonly a symlink via update-alternatives).
+resolve_system_java_home() {
+  local java_bin="$1"
+  if [[ "$OS" == "mac" ]] && [[ -x /usr/libexec/java_home ]]; then
+    local mac_home
+    mac_home=$(/usr/libexec/java_home -v 21 2>/dev/null)
+    if [[ -n "$mac_home" ]]; then
+      echo "$mac_home"
+      return
+    fi
+  fi
+  local resolved="$java_bin"
+  if check_command readlink; then
+    local link
+    link=$(readlink -f "$java_bin" 2>/dev/null || readlink "$java_bin" 2>/dev/null)
+    [[ -n "$link" ]] && resolved="$link"
+  fi
+  dirname "$(dirname "$resolved")"
+}
+
 use_or_install_java() {
   # Prefer the managed per-user JRE if present (idempotent across runs)
   if [[ -x "$JAVA_DIR/bin/java" ]]; then
@@ -253,10 +297,28 @@ use_or_install_java() {
     return
   fi
 
-  # Install managed JRE — ensures JAVA_HOME is always explicitly set and
-  # persisted to RC files regardless of any system Java that may be present.
-  # Relying on an unmanaged system Java risks JAVA_HOME being unset when
-  # Tomcat starts in a new terminal, causing cryptic JVM flag errors.
+  # If a Java 21 is already on PATH, leave it alone — don't shadow a perfectly
+  # good system Java 21 (any build/minor version) with our own pinned Zulu
+  # download. This mirrors the Windows script's existing behavior, which
+  # already checks the system Java's major version before installing.
+  if check_command java; then
+    local sys_java_bin sys_java_major
+    sys_java_bin="$(command -v java)"
+    sys_java_major="$(get_java_major_version "$sys_java_bin")"
+    if [[ "$sys_java_major" == "21" ]]; then
+      export JAVA_HOME="$(resolve_system_java_home "$sys_java_bin")"
+      echo "☕ System Java 21 detected ($sys_java_bin) — leaving it in place."
+      "$sys_java_bin" -version
+      # Deliberately do NOT call persist_java_env here: the user's shell
+      # already resolves `java` to this install on its own. Writing our own
+      # JAVA_HOME into their RC file would silently override a newer/other
+      # Java 21 build on every future terminal.
+      return
+    fi
+  fi
+
+  # No usable Java 21 found on the system — install our managed JRE and
+  # persist JAVA_HOME so every new terminal picks it up.
   install_zulu_jre
   export JAVA_HOME="$JAVA_DIR"
   export PATH="$JAVA_HOME/bin:$PATH"
@@ -340,10 +402,23 @@ if [[ -n "$_TOMCAT_STARTUP" ]]; then
   # by the shell when Tomcat sources the file at startup/shutdown.
   _TMP=$(mktemp)
   {
-    cat <<'SETENV_JAVA'
+    if [[ "$JAVA_HOME" == "$JAVA_DIR" ]]; then
+      # Managed JRE: write ${HOME}-relative paths so setenv.sh works for any
+      # user, not just the one who ran the installer. The single-quoted
+      # heredoc (<<'SETENV_JAVA') prevents ${HOME} from being expanded now —
+      # the literal text is written into setenv.sh and expanded by the shell
+      # when Tomcat sources the file at startup/shutdown.
+      cat <<'SETENV_JAVA'
 export JAVA_HOME="${HOME}/.liferay-course-runtime/zulu-java-21"
 export JRE_HOME="${HOME}/.liferay-course-runtime/zulu-java-21"
 SETENV_JAVA
+    else
+      # An existing system Java 21 is being used (left in place, per
+      # use_or_install_java) — point Tomcat at its actual resolved path
+      # instead of the managed-JRE path, which doesn't exist in this case.
+      printf 'export JAVA_HOME=%q\n' "$JAVA_HOME"
+      printf 'export JRE_HOME=%q\n' "$JAVA_HOME"
+    fi
     if [[ -f "$_SETENV" ]]; then
       grep -v '^export JAVA_HOME=' "$_SETENV" \
         | grep -v '^export JRE_HOME=' \


### PR DESCRIPTION
Changes:

content-manager-course-setup.sh
- Add get_java_major_version(java_bin): parses `java -version` output in both quoted ("21.0.11") and unquoted (openjdk 21) forms; normalises legacy 1.x strings to the real major (1.8.0_411 -> 8). Mirrors the existing Get-JavaMajorVersion logic in the .ps1.
- Add resolve_system_java_home(java_bin): resolves the real JAVA_HOME for a system java binary via /usr/libexec/java_home on macOS and readlink symlink resolution on Linux.
- use_or_install_java(): before falling through to install_zulu_jre, check if there is a java on PATH whose major version is 21. If so, export JAVA_HOME to the resolved home and return early — no download, no persist_java_env() call (which was the line overwriting .bashrc).
- Tomcat setenv.sh injection: write the ${HOME}-relative managed-JRE path only when the managed JRE was actually used/installed; otherwise write the real resolved JAVA_HOME so Tomcat starts with the correct Java.

content-manager-course-setup.ps1
- Track $usingManagedJRE flag across the three Java selection branches.
- When system Java 21 is used (the existing else branch), resolve $env:JAVA_HOME from the system java binary path so the setenv.bat injection below has a valid path to write.
- setenv.bat injection: conditional on $usingManagedJRE — uses %USERPROFILE%-relative path for managed JRE (preserving existing behaviour), or the real resolved JAVA_HOME when the system Java is used (fixing the mirror of the .sh bug where Tomcat was pointed at a managed-JRE directory that did not exist).