### PR TITLE
fix: install a JDK instead of a JRE in the course setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Liferay's Course Launcher tool automatically prepares your system and sets up a 
 
 This tool:
 
-* Checks if Java 21 is installed in your system. If not, it installs Zulu JRE 21 from Azul.
+* Checks if a Java 21 JDK is installed in your system. If not, it installs Zulu JDK 21 from Azul.
 * Downloads and configures the course workspace.
 * Initializes the local Liferay DXP bundle.
 

--- a/content-manager-course-setup.ps1
+++ b/content-manager-course-setup.ps1
@@ -7,8 +7,11 @@ function install-course {
 
     # === CONFIGURATION ===
     $JavaRequiredVersion = 21
-    $ZuluDownloadUrl = "https://cdn.azul.com/zulu/bin/zulu21.52.15-ca-jre21.0.12-win_x64.zip"
-    # Managed JRE lives in a stable, user-level directory (mirrors the shell
+    # A JDK, not a JRE: Liferay starts Elasticsearch 8 as a child process for
+    # search, and its entitlement subsystem needs the jdk.attach module that
+    # only a full JDK ships. See Test-FullJdk below.
+    $ZuluDownloadUrl = "https://cdn.azul.com/zulu/bin/zulu21.52.15-ca-jdk21.0.12-win_x64.zip"
+    # Managed JDK lives in a stable, user-level directory (mirrors the shell
     # script's ${HOME}/.liferay-course-runtime/zulu-java-21 path).
     # A fixed path lets setenv.bat reference %USERPROFILE% instead of an
     # absolute path that only works for the user who ran the installer.
@@ -111,18 +114,51 @@ function Get-JavaMajorVersion {
     return [int]$parts[0]
 }
 
+# True when the given java.exe belongs to a full JDK rather than a JRE.
+# Liferay starts Elasticsearch 8 as a child process for search, and its
+# entitlement subsystem requires the jdk.attach module: on a JRE that process
+# dies during JVM boot layer initialization with
+#   FindException: Module jdk.attach not found, required by org.elasticsearch.entitlement
+# leaving the portal running with search permanently broken. Probing for the
+# module itself — rather than for javac.exe — also rejects trimmed or
+# jlink-built runtimes that ship a compiler but omit jdk.attach. Mirrors
+# is_full_jdk in content-manager-course-setup.sh.
+function Test-FullJdk {
+    param([string]$JavaExe)
+
+    if (-not ($JavaExe -and (Test-Path $JavaExe))) { return $false }
+
+    # Start-Process with redirected streams, as elsewhere in this script: java
+    # writes to stderr, which PowerShell turns into a terminating error while
+    # $ErrorActionPreference = "Stop".
+    $tmpOut = [System.IO.Path]::GetTempFileName()
+    $tmpErr = [System.IO.Path]::GetTempFileName()
+    try {
+        Start-Process -FilePath $JavaExe -ArgumentList '--list-modules' `
+              -NoNewWindow -Wait `
+              -RedirectStandardError $tmpErr -RedirectStandardOutput $tmpOut | Out-Null
+        $modules = Get-Content $tmpOut -Raw
+    } catch {
+        return $false
+    } finally {
+        Remove-Item $tmpOut, $tmpErr -ErrorAction SilentlyContinue
+    }
+
+    return ($modules -match '(?m)^jdk\.attach')
+}
+
     # === Java Installation (user-level, shared across all courses) ===
     $JavaMarkerFile = Join-Path $JavaInstallDir ".installed"
 
-    function Install-ZuluJRE {
-        Write-Host "⬇️ Installing Zulu JRE to: $JavaInstallDir"
-        $zipFile = "$env:TEMP\zulu-jre.zip"
+    function Install-ZuluJdk {
+        Write-Host "⬇️ Installing Zulu JDK to: $JavaInstallDir"
+        $zipFile = "$env:TEMP\zulu-jdk.zip"
 
         $ProgressPreference = 'SilentlyContinue'
         try {
             Invoke-WebRequest -Uri $ZuluDownloadUrl -OutFile $zipFile -UseBasicParsing
         } catch {
-            Write-Host "❌ Could not download Zulu JRE."
+            Write-Host "❌ Could not download Zulu JDK."
             Write-Host "   URL: $ZuluDownloadUrl"
             Write-Host "   Error: $_"
             Write-Host "   Please check your internet connection and try again."
@@ -138,14 +174,31 @@ function Get-JavaMajorVersion {
         Expand-Archive -Path $zipFile -DestinationPath $tmpExtract
         Remove-Item $zipFile
         $unzipped = Get-ChildItem $tmpExtract | Where-Object { $_.PsIsContainer } | Select-Object -First 1
+        # Wipe any previous runtime rather than merging into it, so a JRE left
+        # behind by an older version of this script cannot survive as a mix of
+        # old and new files. The directory name is deliberately unchanged, so
+        # the user environment variable and any bundle's setenv.bat keep
+        # pointing at the right place.
+        if (Test-Path $JavaInstallDir) { Remove-Item $JavaInstallDir -Recurse -Force }
         New-Item -ItemType Directory -Path $JavaInstallDir -Force | Out-Null
         Move-Item -Path (Join-Path $unzipped.FullName "*") -Destination $JavaInstallDir -Force
         Remove-Item $tmpExtract -Recurse -Force
 
+        if (-not (Test-FullJdk (Join-Path $JavaInstallDir "bin\java.exe"))) {
+            Write-Host "❌ The Java runtime downloaded from Azul is not a full JDK."
+            Write-Host "   Installed at: $JavaInstallDir"
+            Write-Host "   URL: $ZuluDownloadUrl"
+            Write-Host "   Liferay's search engine cannot start without one."
+            Write-Host "   Please contact support and share this message."
+            exit 1
+        }
+
         $env:JAVA_HOME = $JavaInstallDir
         $env:Path = "$JavaInstallDir\bin;$env:Path"
 
-        New-Item $JavaMarkerFile -ItemType File | Out-Null
+        # -Force so a re-install over a previous (JRE) runtime does not fail on
+        # an already-existing marker file.
+        New-Item $JavaMarkerFile -ItemType File -Force | Out-Null
         Write-Host "✅ Java installed at $JavaInstallDir"
         java -version
 
@@ -171,27 +224,43 @@ function Get-JavaMajorVersion {
     }
 
     $javaMajor = Get-JavaMajorVersion
-    $usingManagedJRE = $false
+    $usingManagedJdk = $false
 
-    if ($javaMajor -ne $JavaRequiredVersion) {
-        if (Test-Path $JavaMarkerFile) {
-            Write-Host "☕ Using previously installed Java at $JavaInstallDir"
-            $env:JAVA_HOME = $JavaInstallDir
-            $env:Path = "$JavaInstallDir\bin;$env:Path"
-            $usingManagedJRE = $true
-        } else {
-            Install-ZuluJRE
-            $usingManagedJRE = $true
-        }
-    } else {
-        Write-Host "☕ System Java version $javaMajor is OK."
-        # Resolve JAVA_HOME from the system java binary so the setenv.bat
-        # injection below can point Tomcat at the real install, not the
-        # managed-JRE path (which doesn't exist when the system Java is used).
+    # A system Java 21 is only good enough if it is a full JDK. Resolve
+    # JAVA_HOME from the system java binary too, so the setenv.bat injection
+    # below can point Tomcat at the real install rather than the managed-JDK
+    # path (which doesn't exist when the system Java is used).
+    $systemJavaHome = $null
+    if ($javaMajor -eq $JavaRequiredVersion) {
         try {
             $sysJavaCmd = (Get-Command java -ErrorAction Stop).Source
-            $env:JAVA_HOME = Split-Path (Split-Path $sysJavaCmd -Parent) -Parent
+            $candidateHome = Split-Path (Split-Path $sysJavaCmd -Parent) -Parent
+            if (Test-FullJdk (Join-Path $candidateHome "bin\java.exe")) {
+                $systemJavaHome = $candidateHome
+            } else {
+                Write-Host "☕ System Java $javaMajor found at $candidateHome, but it is a JRE rather than a JDK."
+                Write-Host "   Liferay's search engine needs a JDK, so the course JDK will be installed."
+            }
         } catch { }
+    }
+
+    if ($systemJavaHome) {
+        Write-Host "☕ System Java $javaMajor JDK is OK."
+        $env:JAVA_HOME = $systemJavaHome
+    } elseif ((Test-Path $JavaMarkerFile) -and (Test-FullJdk (Join-Path $JavaInstallDir "bin\java.exe"))) {
+        Write-Host "☕ Using previously installed Java at $JavaInstallDir"
+        $env:JAVA_HOME = $JavaInstallDir
+        $env:Path = "$JavaInstallDir\bin;$env:Path"
+        $usingManagedJdk = $true
+    } else {
+        # Reached either on a first run, or when a previous run of an older
+        # version of this script left a JRE at $JavaInstallDir.
+        if (Test-Path $JavaMarkerFile) {
+            Write-Host "♻️  The course Java runtime at $JavaInstallDir is a JRE, which cannot run"
+            Write-Host "   Liferay's search engine. Replacing it with a full JDK..."
+        }
+        Install-ZuluJdk
+        $usingManagedJdk = $true
     }
 
     # Verify Java 21 is active before running Gradle.
@@ -227,6 +296,16 @@ function Get-JavaMajorVersion {
         Write-Host "   JAVA_HOME: $($env:JAVA_HOME)"
         Write-Host "   Java binary: $verifyJavaExe"
         Write-Host "   If Java $JavaRequiredVersion was just installed, open a new terminal and re-run the script."
+        exit 1
+    }
+    if (-not (Test-FullJdk $verifyJavaExe)) {
+        Write-Host "❌ Java $JavaRequiredVersion was found, but it is a JRE rather than a full JDK."
+        Write-Host "   JAVA_HOME: $($env:JAVA_HOME)"
+        Write-Host "   Java binary: $verifyJavaExe"
+        Write-Host "   Liferay starts Elasticsearch as a child process for search, and that"
+        Write-Host "   process cannot boot without the jdk.attach module a JDK provides."
+        Write-Host "   Please install a Java $JavaRequiredVersion JDK, or clear JAVA_HOME and re-run this"
+        Write-Host "   script so it can install the course JDK for you."
         exit 1
     }
 
@@ -292,16 +371,16 @@ function Get-JavaMajorVersion {
         # Use %USERPROFILE% (evaluated at Tomcat start time) instead of an
         # absolute path so the file works for any user on any machine.
         # Tomcat checks JRE_HOME first; without it, catalina.bat may resolve
-        # to the system Java instead of our managed JRE 21.
-        if ($usingManagedJRE) {
-            # Managed JRE: write %USERPROFILE%-relative paths so setenv.bat
+        # to the system Java instead of our managed JDK 21.
+        if ($usingManagedJdk) {
+            # Managed JDK: write %USERPROFILE%-relative paths so setenv.bat
             # works for any user, not just the one who ran the installer.
             $javaHomeLine = 'set "JAVA_HOME=%USERPROFILE%\.liferay-course-runtime\zulu-java-21"'
             $jreHomeLine  = 'set "JRE_HOME=%USERPROFILE%\.liferay-course-runtime\zulu-java-21"'
             $tomcatJavaNote = "%USERPROFILE%\.liferay-course-runtime\zulu-java-21"
         } else {
             # System Java 21 is being used (left in place) — point Tomcat at
-            # its actual resolved path, not the managed-JRE path (which doesn't
+            # its actual resolved path, not the managed-JDK path (which doesn't
             # exist when the system Java was used instead).
             $javaHomeLine = "set `"JAVA_HOME=$($env:JAVA_HOME)`""
             $jreHomeLine  = "set `"JRE_HOME=$($env:JAVA_HOME)`""

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -353,29 +353,15 @@ resolve_system_java_home() {
 }
 
 use_or_install_java() {
-  # Prefer the managed per-user JDK if present (idempotent across runs), but
-  # only when it really is a JDK: earlier versions of this script installed a
-  # JRE at the same path, and reusing it would keep search broken forever.
-  if [[ -x "$JAVA_DIR/bin/java" ]]; then
-    if is_full_jdk "$JAVA_DIR/bin/java"; then
-      export JAVA_HOME="$JAVA_DIR"
-      export PATH="$JAVA_HOME/bin:$PATH"
-      # Ensure the RC file is up to date even when Java was installed by a
-      # previous run (e.g., the entry may be missing if the first run used an
-      # older script version that only wrote to files that already existed).
-      persist_java_env
-      return
-    fi
-    echo "♻️  The course Java runtime at $JAVA_DIR is a JRE, which cannot run"
-    echo "   Liferay's search engine. Replacing it with a full JDK..."
-  fi
-
-  # If a Java 21 JDK is already on PATH, leave it alone — don't shadow a
-  # perfectly good system Java 21 (any build/minor version) with our own pinned
-  # Zulu download. This mirrors the Windows script's existing behavior, which
-  # already checks the system Java's major version before installing.
+  # Prefer a Java 21 JDK the user already has. Don't shadow a perfectly good
+  # system install with our own pinned Zulu download, and don't touch their
+  # shell RC file when we don't have to — nothing is installed or persisted on
+  # this path. Checked before the managed runtime so that a developer who keeps
+  # their own JDK is not quietly switched onto ours by an earlier run. Mirrors
+  # content-manager-course-setup.ps1, which already checks the system Java
+  # before its managed runtime.
   if check_command java; then
-    local sys_java_bin sys_java_major
+    local sys_java_bin sys_java_major sys_java_home
     sys_java_bin="$(command -v java)"
     # `|| true` matters under `set -e`: get_java_major_version returns 1 when it
     # cannot parse a version, which is exactly what macOS's /usr/bin/java shim
@@ -383,7 +369,6 @@ use_or_install_java() {
     # this, the script aborts silently on a clean Mac instead of installing Java.
     sys_java_major="$(get_java_major_version "$sys_java_bin" || true)"
     if [[ "$sys_java_major" == "21" ]]; then
-      local sys_java_home
       sys_java_home="$(resolve_system_java_home "$sys_java_bin")"
       # Check the resolved home as well as the binary on PATH: the resolved
       # path is what gets written into Tomcat's setenv.sh, and on macOS
@@ -399,8 +384,25 @@ use_or_install_java() {
         return
       fi
       echo "☕ System Java 21 found ($sys_java_bin), but it is a JRE rather than a JDK."
-      echo "   Liferay's search engine needs a JDK, so the course JDK will be installed."
+      echo "   Liferay's search engine needs a JDK, so the course JDK will be used."
     fi
+  fi
+
+  # Fall back to the managed per-user JDK when a previous run installed one, but
+  # only when it really is a JDK: earlier versions of this script installed a
+  # JRE at the same path, and reusing it would keep search broken forever.
+  if [[ -x "$JAVA_DIR/bin/java" ]]; then
+    if is_full_jdk "$JAVA_DIR/bin/java"; then
+      export JAVA_HOME="$JAVA_DIR"
+      export PATH="$JAVA_HOME/bin:$PATH"
+      # Ensure the RC file is up to date even when Java was installed by a
+      # previous run (e.g., the entry may be missing if the first run used an
+      # older script version that only wrote to files that already existed).
+      persist_java_env
+      return
+    fi
+    echo "♻️  The course Java runtime at $JAVA_DIR is a JRE, which cannot run"
+    echo "   Liferay's search engine. Replacing it with a full JDK..."
   fi
 
   # No usable Java 21 JDK found on the system — install our managed JDK and

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -150,17 +150,17 @@ fetch_text() {
   fi
 }
 
-install_zulu_jre() {
+install_zulu_jdk() {
   local ARCH
   ARCH=$(uname -m)
   [[ "$ARCH" == "x86_64" ]] && ARCH="x64"
   [[ "$ARCH" =~ (arm64|aarch64) ]] && ARCH="aarch64"
 
-  echo "🌐 Fetching Zulu JRE URL..."
+  echo "🌐 Fetching Zulu JDK URL..."
   # The Azul API expects 'macos', not 'mac'
   local AZUL_OS="${OS}"
   [[ "$AZUL_OS" == "mac" ]] && AZUL_OS="macos"
-  local ZULU_API_URL="https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?java_version=${JAVA_REQUIRED_VERSION}&os=${AZUL_OS}&arch=${ARCH}&ext=tar.gz&bundle_type=jre&javafx=false&release_status=ga&hw_bitness=64"
+  local ZULU_API_URL="https://api.azul.com/zulu/download/community/v1.0/bundles/latest/?java_version=${JAVA_REQUIRED_VERSION}&os=${AZUL_OS}&arch=${ARCH}&ext=tar.gz&bundle_type=jdk&javafx=false&release_status=ga&hw_bitness=64"
   local ZULU_API_RESPONSE ZULU_URL
 
   set +e
@@ -169,7 +169,7 @@ install_zulu_jre() {
   set -e
 
   if [[ $FETCH_EXIT -ne 0 ]] || [[ -z "$ZULU_API_RESPONSE" ]]; then
-    echo "❌ Could not reach the Azul API to fetch the Zulu JRE download URL."
+    echo "❌ Could not reach the Azul API to fetch the Zulu JDK download URL."
     echo "   Endpoint: https://api.azul.com/zulu/download/community/v1.0/bundles/latest/"
     echo "   Please check your internet connection and try again."
     echo "   If the problem persists, contact support and share this message."
@@ -187,13 +187,26 @@ install_zulu_jre() {
     exit 1
   fi
 
-  echo "⬇️ Downloading Zulu JRE..."
+  echo "⬇️ Downloading Zulu JDK..."
+  # Wipe any previous runtime rather than extracting on top of it, so a JRE
+  # left behind by an older version of this script cannot survive as a mix of
+  # old and new files. The directory name is deliberately unchanged, so the
+  # RC-file entry and any bundle's setenv.sh keep pointing at the right place.
+  rm -rf "$JAVA_DIR"
   mkdir -p "$JAVA_DIR"
   local TMP_TAR="${RUNTIME_DIR}/zulu.tar.gz"
   mkdir -p "$RUNTIME_DIR"
   fetch "$ZULU_URL" "$TMP_TAR"
   tar -xzf "$TMP_TAR" -C "$JAVA_DIR" --strip-components=1
   rm -f "$TMP_TAR"
+
+  if ! is_full_jdk "$JAVA_DIR/bin/java"; then
+    echo "❌ The Java runtime downloaded from Azul is not a full JDK."
+    echo "   Installed at: $JAVA_DIR"
+    echo "   Liferay's search engine cannot start without one."
+    echo "   Please contact support and share this message."
+    exit 1
+  fi
 
   export JAVA_HOME="$JAVA_DIR"
   export PATH="$JAVA_HOME/bin:$PATH"
@@ -241,6 +254,21 @@ persist_java_env() {
   echo "   Or simply open a new terminal — it will already use Java 21."
 }
 
+# True when the given java binary belongs to a full JDK rather than a JRE.
+# Liferay starts Elasticsearch 8 as a child process for search, and its
+# entitlement subsystem requires the jdk.attach module: on a JRE that process
+# dies during JVM boot layer initialization with
+#   FindException: Module jdk.attach not found, required by org.elasticsearch.entitlement
+# leaving the portal running with search permanently broken. Probing for the
+# module itself — rather than for `javac` — also rejects trimmed or jlink-built
+# runtimes that ship a compiler but omit jdk.attach. Mirrors Test-FullJdk in
+# content-manager-course-setup.ps1.
+is_full_jdk() {
+  local java_bin="$1"
+  [[ -x "$java_bin" ]] || return 1
+  "$java_bin" --list-modules 2>/dev/null | grep -q '^jdk\.attach'
+}
+
 # Returns the major version (e.g. "21") of the given java binary on stdout,
 # or nothing if it can't be determined. Handles both modern version strings
 # ("21.0.11" -> 21) and legacy 1.x strings ("1.8.0_411" -> 8). Mirrors
@@ -286,40 +314,59 @@ resolve_system_java_home() {
 }
 
 use_or_install_java() {
-  # Prefer the managed per-user JRE if present (idempotent across runs)
+  # Prefer the managed per-user JDK if present (idempotent across runs), but
+  # only when it really is a JDK: earlier versions of this script installed a
+  # JRE at the same path, and reusing it would keep search broken forever.
   if [[ -x "$JAVA_DIR/bin/java" ]]; then
-    export JAVA_HOME="$JAVA_DIR"
-    export PATH="$JAVA_HOME/bin:$PATH"
-    # Ensure the RC file is up to date even when Java was installed by a
-    # previous run (e.g., the entry may be missing if the first run used an
-    # older script version that only wrote to files that already existed).
-    persist_java_env
-    return
+    if is_full_jdk "$JAVA_DIR/bin/java"; then
+      export JAVA_HOME="$JAVA_DIR"
+      export PATH="$JAVA_HOME/bin:$PATH"
+      # Ensure the RC file is up to date even when Java was installed by a
+      # previous run (e.g., the entry may be missing if the first run used an
+      # older script version that only wrote to files that already existed).
+      persist_java_env
+      return
+    fi
+    echo "♻️  The course Java runtime at $JAVA_DIR is a JRE, which cannot run"
+    echo "   Liferay's search engine. Replacing it with a full JDK..."
   fi
 
-  # If a Java 21 is already on PATH, leave it alone — don't shadow a perfectly
-  # good system Java 21 (any build/minor version) with our own pinned Zulu
-  # download. This mirrors the Windows script's existing behavior, which
+  # If a Java 21 JDK is already on PATH, leave it alone — don't shadow a
+  # perfectly good system Java 21 (any build/minor version) with our own pinned
+  # Zulu download. This mirrors the Windows script's existing behavior, which
   # already checks the system Java's major version before installing.
   if check_command java; then
     local sys_java_bin sys_java_major
     sys_java_bin="$(command -v java)"
-    sys_java_major="$(get_java_major_version "$sys_java_bin")"
+    # `|| true` matters under `set -e`: get_java_major_version returns 1 when it
+    # cannot parse a version, which is exactly what macOS's /usr/bin/java shim
+    # prints on a machine with no JDK ("Unable to locate a Java Runtime"). Without
+    # this, the script aborts silently on a clean Mac instead of installing Java.
+    sys_java_major="$(get_java_major_version "$sys_java_bin" || true)"
     if [[ "$sys_java_major" == "21" ]]; then
-      export JAVA_HOME="$(resolve_system_java_home "$sys_java_bin")"
-      echo "☕ System Java 21 detected ($sys_java_bin) — leaving it in place."
-      "$sys_java_bin" -version
-      # Deliberately do NOT call persist_java_env here: the user's shell
-      # already resolves `java` to this install on its own. Writing our own
-      # JAVA_HOME into their RC file would silently override a newer/other
-      # Java 21 build on every future terminal.
-      return
+      local sys_java_home
+      sys_java_home="$(resolve_system_java_home "$sys_java_bin")"
+      # Check the resolved home as well as the binary on PATH: the resolved
+      # path is what gets written into Tomcat's setenv.sh, and on macOS
+      # /usr/libexec/java_home can name a different install than `java` does.
+      if is_full_jdk "$sys_java_bin" && is_full_jdk "$sys_java_home/bin/java"; then
+        export JAVA_HOME="$sys_java_home"
+        echo "☕ System Java 21 JDK detected ($sys_java_bin) — leaving it in place."
+        "$sys_java_bin" -version
+        # Deliberately do NOT call persist_java_env here: the user's shell
+        # already resolves `java` to this install on its own. Writing our own
+        # JAVA_HOME into their RC file would silently override a newer/other
+        # Java 21 build on every future terminal.
+        return
+      fi
+      echo "☕ System Java 21 found ($sys_java_bin), but it is a JRE rather than a JDK."
+      echo "   Liferay's search engine needs a JDK, so the course JDK will be installed."
     fi
   fi
 
-  # No usable Java 21 found on the system — install our managed JRE and
+  # No usable Java 21 JDK found on the system — install our managed JDK and
   # persist JAVA_HOME so every new terminal picks it up.
-  install_zulu_jre
+  install_zulu_jdk
   export JAVA_HOME="$JAVA_DIR"
   export PATH="$JAVA_HOME/bin:$PATH"
 }
@@ -353,6 +400,16 @@ if [[ "$_JAVA_VER" != "21" ]]; then
   echo "   JAVA_HOME: ${JAVA_HOME:-not set}"
   echo "   Java binary: $_JAVA_BIN"
   echo "   If Java 21 was just installed, open a new terminal and re-run the script."
+  exit 1
+fi
+if ! is_full_jdk "$_JAVA_BIN"; then
+  echo "❌ Java 21 was found, but it is a JRE rather than a full JDK."
+  echo "   JAVA_HOME: ${JAVA_HOME:-not set}"
+  echo "   Java binary: $_JAVA_BIN"
+  echo "   Liferay starts Elasticsearch as a child process for search, and that"
+  echo "   process cannot boot without the jdk.attach module a JDK provides."
+  echo "   Please install a Java 21 JDK, or unset JAVA_HOME and re-run this"
+  echo "   script so it can install the course JDK for you."
   exit 1
 fi
 

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -200,6 +200,20 @@ install_zulu_jdk() {
   tar -xzf "$TMP_TAR" -C "$JAVA_DIR" --strip-components=1
   rm -f "$TMP_TAR"
 
+  # Since 21.0.12, Azul ships the macOS bundles as a signed .jdk app bundle, so
+  # --strip-components=1 leaves Contents/Home/{bin,lib,...} rather than bin/
+  # directly; 21.0.1 and earlier were flat, and Linux and Windows still are.
+  # Flatten it so "$JAVA_DIR/bin/java" is valid on every platform — that literal
+  # path is written into the shell RC file and into Tomcat's setenv.sh, so it has
+  # to be the real Java home.
+  if [[ ! -x "$JAVA_DIR/bin/java" ]] && [[ -x "$JAVA_DIR/Contents/Home/bin/java" ]]; then
+    local FLATTEN_DIR="${RUNTIME_DIR}/.java-home-tmp"
+    rm -rf "$FLATTEN_DIR"
+    mv "$JAVA_DIR/Contents/Home" "$FLATTEN_DIR"
+    rm -rf "$JAVA_DIR"
+    mv "$FLATTEN_DIR" "$JAVA_DIR"
+  fi
+
   if ! is_full_jdk "$JAVA_DIR/bin/java"; then
     echo "❌ The Java runtime downloaded from Azul is not a full JDK."
     echo "   Installed at: $JAVA_DIR"

--- a/content-manager-course-setup.sh
+++ b/content-manager-course-setup.sh
@@ -243,23 +243,48 @@ persist_java_env() {
     local RC="${HOME}/.bashrc"
   fi
 
-  local MARKER=".liferay-course-runtime/zulu-java-21"
+  local BEGIN_MARKER="# BEGIN Liferay Course Launcher"
+  local END_MARKER="# END Liferay Course Launcher"
 
-  # Remove any line from a previous run that references our managed JRE path.
-  if grep -qF "$MARKER" "$RC" 2>/dev/null; then
+  # Remove any entry from a previous run before re-appending. This drops the
+  # delimited block written below, and also the older undelimited format: that
+  # cleanup matched only lines containing the runtime path, so the comment and
+  # the `export PATH="$JAVA_HOME/bin:$PATH"` line never matched and piled up on
+  # every run — leaving orphaned PATH lines that prepended whatever JAVA_HOME
+  # happened to hold at that point in the file.
+  if [[ -f "$RC" ]]; then
     local _tmp_rc
     _tmp_rc=$(mktemp)
-    grep -vF "$MARKER" "$RC" > "$_tmp_rc" || true
+    awk -v b="$BEGIN_MARKER" -v e="$END_MARKER" \
+        -v c="# Added by Liferay Course Launcher" \
+        -v j='export JAVA_HOME="${HOME}/.liferay-course-runtime/zulu-java-21"' \
+        -v p='export PATH="$JAVA_HOME/bin:$PATH"' '
+      $0 == b { inblock = 1; next }
+      $0 == e { inblock = 0; next }
+      inblock { next }
+      $0 == c { legacy = 1; next }
+      legacy && ($0 == j || $0 == p) { next }
+      { legacy = 0; print }
+    ' "$RC" | awk '
+      { lines[NR] = $0 }
+      END {
+        last = NR
+        while (last > 0 && lines[last] ~ /^[[:space:]]*$/) { last-- }
+        for (i = 1; i <= last; i++) { print lines[i] }
+      }
+    ' > "$_tmp_rc"
     mv "$_tmp_rc" "$RC"
   fi
 
-  # Append a fresh entry. ${HOME} and $JAVA_HOME are written as literal text
-  # (single-quoted printf) so the RC file is portable for any username — the
-  # shell expands them when it sources the file on each new terminal session.
+  # Append a fresh entry, fenced by markers so the next run can remove it whole.
+  # ${HOME} and $JAVA_HOME are written as literal text (single-quoted printf) so
+  # the RC file is portable for any username — the shell expands them when it
+  # sources the file on each new terminal session.
   {
-    printf '\n# Added by Liferay Course Launcher\n'
+    printf '\n%s\n' "$BEGIN_MARKER"
     printf 'export JAVA_HOME="${HOME}/.liferay-course-runtime/zulu-java-21"\n'
     printf 'export PATH="$JAVA_HOME/bin:$PATH"\n'
+    printf '%s\n' "$END_MARKER"
   } >> "$RC"
   echo ""
   echo "📝 JAVA_HOME configured in $RC"


### PR DESCRIPTION
@mirandastephane we need to test this with all 3 operating systems and we should also recreate the situation of having previously run the incorrect scripts to determine if this script is enough or if we need to do some cleanup.  